### PR TITLE
fix Behpardakht verify function (remove apiNamespaceUrl from Behpardakht driver)

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -40,7 +40,6 @@ return [
             'apiPurchaseUrl' => 'https://bpm.shaparak.ir/pgwchannel/services/pgw?wsdl',
             'apiPaymentUrl' => 'https://bpm.shaparak.ir/pgwchannel/startpay.mellat',
             'apiVerificationUrl' => 'https://bpm.shaparak.ir/pgwchannel/services/pgw?wsdl',
-            'apiNamespaceUrl' => 'http://interfaces.core.sw.bps.com/',
             'terminalId' => '',
             'username' => '',
             'password' => '',

--- a/src/Drivers/Behpardakht/Behpardakht.php
+++ b/src/Drivers/Behpardakht/Behpardakht.php
@@ -49,7 +49,7 @@ class Behpardakht extends Driver
      * @throws PurchaseFailedException
      * @throws \SoapFault
      */
-    
+
     public function purchase()
     {
         $soap = new \SoapClient($this->settings->apiPurchaseUrl);
@@ -111,18 +111,18 @@ class Behpardakht extends Driver
         $soap = new \SoapClient($this->settings->apiVerificationUrl);
 
         // step1: verify request
-        $verifyResponse = (int)$soap->bpVerifyRequest($data, $this->settings->apiNamespaceUrl)->return;
+        $verifyResponse = (int)$soap->bpVerifyRequest($data)->return;
         if ($verifyResponse != 0) {
             // rollback money and throw exception
-            $soap->bpReversalRequest($data, $this->settings->apiNamespaceUrl);
+            $soap->bpReversalRequest($data);
             throw new InvalidPaymentException($verifyResponse ?? "خطا در عملیات وریفای تراکنش");
         }
 
         // step2: settle request
-        $settleResponse = $soap->bpSettleRequest($data, $this->settings->apiNamespaceUrl)->return;
+        $settleResponse = $soap->bpSettleRequest($data)->return;
         if ($settleResponse != 0) {
             // rollback money and throw exception
-            $soap->bpReversalRequest($data, $this->settings->apiNamespaceUrl);
+            $soap->bpReversalRequest($data);
             throw new InvalidPaymentException($settleResponse ?? "خطا در ثبت درخواست واریز وجه");
         }
 


### PR DESCRIPTION
i think there is extra arguments in verify function for call Behpardakht soap functions. 

exp: 

- bpVerifyRequest($data, $this->settings->apiNamespaceUrl)
- bpReversalRequest($data, $this->settings->apiNamespaceUrl)
- bpSettleRequest($data, $this->settings->apiNamespaceUrl)

**$this->settings->apiNamespaceUrl**  it has no effect on the operation