### PR TITLE
Added optional allowedCards value to Zibal driver.

### DIFF
--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -84,13 +84,6 @@ class Zibal extends Driver
             $description = $this->settings->description;
         }
 
-        $allowedCards = null;
-        if (!empty($details['allowedCards'])) {
-            $allowedCards = $details['allowedCards'];
-        } else {
-            $allowedCards = $this->settings->allowedCards;
-        }
-
         $data = array(
             "merchant"=> $this->settings->merchantId, //required
             "callbackUrl"=> $this->settings->callbackUrl, //required
@@ -98,8 +91,22 @@ class Zibal extends Driver
             "orderId"=> $orderId, //optional
             'mobile' => $mobile, //optional for mpg
             "description" => $description, //optional
-            "allowedCards" => $allowedCards, //optional
         );
+
+        //checking if optional allowedCards parameter exists
+        $allowedCards = null;
+        if (!empty($details['allowedCards'])) {
+            $allowedCards = $details['allowedCards'];
+        } else if(!empty($this->settings->allowedCards)) {
+            $allowedCards = $this->settings->allowedCards;
+        }
+
+        if ($allowedCards != null) {
+            $allowedCards = array(
+                'allowedCards' => $allowedCards,
+            );
+            $data = array_merge($data, $allowedCards);
+        }
 
         $response = $this->client->request(
             'POST',

--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -84,6 +84,13 @@ class Zibal extends Driver
             $description = $this->settings->description;
         }
 
+        $allowedCards = null;
+        if (!empty($details['allowedCards'])) {
+            $allowedCards = $details['allowedCards'];
+        } else {
+            $allowedCards = $this->settings->allowedCards;
+        }
+
         $data = array(
             "merchant"=> $this->settings->merchantId, //required
             "callbackUrl"=> $this->settings->callbackUrl, //required
@@ -91,6 +98,7 @@ class Zibal extends Driver
             "orderId"=> $orderId, //optional
             'mobile' => $mobile, //optional for mpg
             "description" => $description, //optional
+            "allowedCards" => $allowedCards, //optional
         );
 
         $response = $this->client->request(


### PR DESCRIPTION
## Description

Added optional allowedCards value to the $data array in Zibal driver.

## Motivation and context

This addition allows users to send optional allowed bank cards for their zibal payment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.