### PR TITLE
Fix wrong http header

### DIFF
--- a/README-FA.md
+++ b/README-FA.md
@@ -263,6 +263,15 @@ return $payment->purchase(
         // We need the transactionId to verify payment in the future.
 	}
 )->pay();
+
+// Retrieve json response of Redirection (in this case you can handle redirection to bank gateway)
+return $payment->purchase(
+    (new Invoice)->amount(1000), 
+    function($driver, $transactionId) {
+    	// Store transactionId in database.
+        // We need the transactionId to verify payment in the future.
+	}
+)->pay()->toJsonResponse();
 ```
 
 <div dir="rtl">

--- a/README.md
+++ b/README.md
@@ -250,14 +250,14 @@ return $payment->purchase(
 	}
 )->pay()->render();
 
-// Retrieve json format of Redirection (in this case you can handle redirection to bank gateway)
+// Retrieve json response of Redirection (in this case you can handle redirection to bank gateway)
 return $payment->purchase(
     (new Invoice)->amount(1000), 
     function($driver, $transactionId) {
     	// Store transactionId in database.
         // We need the transactionId to verify payment in the future.
 	}
-)->pay()->toJson();
+)->pay()->toJsonResponse();
 ```
 
 #### Verify payment

--- a/src/RedirectionForm.php
+++ b/src/RedirectionForm.php
@@ -3,6 +3,7 @@
 namespace Shetabit\Multipay;
 
 use JsonSerializable;
+use Illuminate\Support\Facades\Response;
 
 class RedirectionForm implements JsonSerializable
 {
@@ -184,6 +185,18 @@ class RedirectionForm implements JsonSerializable
     public function toJson($options = JSON_UNESCAPED_UNICODE) : string
     {
         return json_encode($this, $options);
+    }
+    
+    /**
+     * Retrieve JsonResponse of redirection form
+     *
+     * @param int $options
+     *
+     * @return JsonResponse
+     */
+    public function toJsonResponse($options = JSON_UNESCAPED_UNICODE) : \Illuminate\Http\JsonResponse
+    {
+        return Response::json($this)->setEncodingOptions($options);
     }
 
     /**


### PR DESCRIPTION
According to the document when want to handle the redirection (for example in an api) we can use `toJson` method like below:

```
return $payment->purchase(
    (new Invoice)->amount(1000), 
    function($driver, $transactionId) {
    	// Store transactionId in database.
        // We need the transactionId to verify payment in the future.
	}
)->pay()->toJson();
```
but it will return the json without `Content-Type: application/json` http header and laravel is going to set `Content-Type: text/html` by default.
Using the added method we can directly send the response with the correct http header.
Although it was not the only solution but I think it is a good one. toJson method could be changed too but it could be a breaking change. By this change shetabit/payment documentation should be changed as well.