### PR TITLE
[PHP 8.1] Set jsonSerialize() return type to match interface

### DIFF
--- a/src/RedirectionForm.php
+++ b/src/RedirectionForm.php
@@ -210,8 +210,9 @@ class RedirectionForm implements JsonSerializable
     /**
      * Serialize to json
      *
-     * @return mixed
+     * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
This will fix Deprecated error in PHP 8.1

`PHP Deprecated:  Return type of Shetabit\Multipay\RedirectionForm::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`