### PR TITLE
Fix PayPing driver returned values (cardNumber) & updating it's API a…

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -164,9 +164,9 @@ return [
             'description' => 'payment using paypal',
         ],
         'payping' => [
-            'apiPurchaseUrl' => 'https://api.payping.ir/v1/pay/',
-            'apiPaymentUrl' => 'https://api.payping.ir/v1/pay/gotoipg/',
-            'apiVerificationUrl' => 'https://api.payping.ir/v1/pay/verify/',
+            'apiPurchaseUrl' => 'https://api.payping.ir/v2/pay/',
+            'apiPaymentUrl' => 'https://api.payping.ir/v2/pay/gotoipg/',
+            'apiVerificationUrl' => 'https://api.payping.ir/v2/pay/verify/',
             'merchantId' => '',
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using payping',

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -78,7 +78,6 @@ class Payping extends Driver
             "payerName" => $name,
             "amount" => $this->invoice->getAmount(),
             "payerIdentity" => $mobile ?? $email,
-            "phone" => $mobile,
             "returnUrl" => $this->settings->callbackUrl,
             "description" => $description,
             "clientRefId" => $this->invoice->getUuid(),

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -78,6 +78,7 @@ class Payping extends Driver
             "payerName" => $name,
             "amount" => $this->invoice->getAmount(),
             "payerIdentity" => $mobile ?? $email,
+            "phone" => $mobile,
             "returnUrl" => $this->settings->callbackUrl,
             "description" => $description,
             "clientRefId" => $this->invoice->getUuid(),

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -170,8 +170,9 @@ class Payping extends Driver
         $receipt = $this->createReceipt($refId);
 
         $receipt->detail([
-            "cardNumber" => $body['cardNumber'],
+            "cardNumber" => $body['cardnumber'],
         ]);
+
 
         return $receipt;
     }


### PR DESCRIPTION
Fix PayPing driver returned values (cardNumber) & updating it's API changed from `V1` to `V2`.
Note that their documentation said `cardNumber` return value is correct but it will return as lowser (`cardnumber`).