### PR TITLE
Set dynamic Payment Identity for Sadad

### DIFF
--- a/src/Drivers/Sadad/Sadad.php
+++ b/src/Drivers/Sadad/Sadad.php
@@ -83,10 +83,17 @@ class Sadad extends Driver
             $mobile = "";
         }
 
+        //set PaymentIdentity for payment
+        if (!empty($this->invoice->getDetails()['payment_identity'])) {
+            $paymentIdentity = $this->invoice->getDetails()['payment_identity'];
+        } else {
+            $paymentIdentity = $this->settings->PaymentIdentity;
+        }
+
         $data = array(
             'MerchantId' => $this->settings->merchantId,
             'ReturnUrl' => $this->settings->callbackUrl,
-            'PaymentIdentity' => $this->settings->PaymentIdentity,
+            'PaymentIdentity' => $paymentIdentity,
             'LocalDateTime' => $iranTime->format("m/d/Y g:i:s a"),
             'SignData' => $signData,
             'TerminalId' => $terminalId,


### PR DESCRIPTION
Use payment_identity from invoice details if present otherwise use default settings

For some purpose may need to use different payment identities.