### PR TITLE
fix sadad mode comment

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -201,7 +201,7 @@ return [
             'merchantId' => '',
             'terminalId' => '',
             'callbackUrl' => '',
-            'mode' =>  'normal', // can be normal and PaymentIdentity,
+            'mode' =>  'normal', // can be normal and PaymentByIdentity,
             'PaymentIdentity' => '',
             'description' => 'payment using sadad',
         ],


### PR DESCRIPTION
Replace `PaymentIdentity` with `PaymentByIdentity` in Sadad `mode` hint that commented in `config/payment.php`

In `src/Drivers/Sadad/Sadad.php`
Method `getPurchaseUrl()` and `getPaymentUrl()` compare `$mode` with `"paymentbyidentity"`