### PR TITLE
Fix currency property undefined error + zarinpal

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -181,7 +181,6 @@ return [
             'sandboxApiVerificationUrl' => 'https://sandbox.zarinpal.com/pg/services/WebGate/wsdl',
 
             'mode' => 'normal', // can be normal, sandbox
-            'currency' => '',
             'id' => '', // Specify the email of the PayPal Business account
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using paypal',

--- a/src/Drivers/Aqayepardakht/Aqayepardakht.php
+++ b/src/Drivers/Aqayepardakht/Aqayepardakht.php
@@ -54,7 +54,7 @@ class Aqayepardakht extends Driver
     {
         $data = [
             'pin' => $this->settings->mode === "normal" ? $this->settings->pin : "sandbox",
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'callback' => $this->settings->callbackUrl,
             'invoice_id' => $this->settings->invoice_id,
             'mobile' => $this->settings->mobile,
@@ -111,7 +111,7 @@ class Aqayepardakht extends Driver
         }
         $data = [
             'pin' => $this->settings->pin,
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'transid' => $transid
         ];
         $response = $this->client

--- a/src/Drivers/Asanpardakht/Asanpardakht.php
+++ b/src/Drivers/Asanpardakht/Asanpardakht.php
@@ -200,7 +200,7 @@ class Asanpardakht extends Driver
             'serviceTypeId' => 1,
             'merchantConfigurationId' => $this->settings->merchantConfigID,
             'localInvoiceId' => $this->invoice->getUuid(),
-            'amountInRials' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amountInRials' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'localDate' => $this->getTime()['content'],
             'callbackURL' => $this->settings->callbackUrl . $query,
             'paymentId' => "0",

--- a/src/Drivers/Atipay/Atipay.php
+++ b/src/Drivers/Atipay/Atipay.php
@@ -73,7 +73,7 @@ class Atipay extends Driver
      */
     public function purchase()
     {
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
 
         $order_id = $this->invoice->getUuid();
         $mobile = $this->extractDetails('mobile');
@@ -128,7 +128,7 @@ class Atipay extends Driver
         $payment_id = $params['reservationNumber'];
         if ($result['success'] == 1) { //will verify here
             $apiKey = $this->settings->apikey;
-            $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+            $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
             $verify_params = array('apiKey' => $apiKey,
                 'referenceNumber' => $params['referenceNumber']
             );

--- a/src/Drivers/Azki/Azki.php
+++ b/src/Drivers/Azki/Azki.php
@@ -96,7 +96,7 @@ class Azki extends Driver
         );
 
         $data = [
-            "amount"        => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            "amount"        => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             "redirect_uri"  => $callback,
             "fallback_uri"  => $fallback,
             "provider_id"   => $order_id,
@@ -181,7 +181,7 @@ class Azki extends Driver
 
         $new_items = array_map(
             function ($item) {
-                $item['amount'] *= ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+                $item['amount'] *= (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
                 return $item;
             },
             $this->invoice->getDetails()['items'] ?? []

--- a/src/Drivers/Behpardakht/Behpardakht.php
+++ b/src/Drivers/Behpardakht/Behpardakht.php
@@ -230,7 +230,7 @@ class Behpardakht extends Driver
             'userName' => $this->settings->username,
             'userPassword' => $this->settings->password,
             'callBackUrl' => $this->settings->callbackUrl,
-            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'localDate' => Carbon::now()->format('Ymd'),
             'localTime' => Carbon::now()->format('Gis'),
             'orderId' => crc32($this->invoice->getUuid()),

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -68,7 +68,7 @@ class Digipay extends Driver
             $phone = $details['mobile'];
         }
         $data = array(
-            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1), // convert to rial
             'phone' => $phone,
             'providerId' => $this->invoice->getUuid(),
             'redirectUrl' => $this->settings->callbackUrl,

--- a/src/Drivers/Fanavacard/Fanavacard.php
+++ b/src/Drivers/Fanavacard/Fanavacard.php
@@ -91,7 +91,7 @@ class Fanavacard extends Driver
     public function verify(): ReceiptInterface
     {
         $transaction_amount = Request::input('transactionAmount');
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         if ($amount == $transaction_amount) {
             $param = ['Token'=>Request::input('token'), 'RefNum'=>Request::input('RefNum')];
@@ -158,7 +158,7 @@ class Fanavacard extends Driver
                 'WSContext'=> $this->getWsContext(),
                 'TransType'=>'EN_GOODS',
                 'ReserveNum'=>$this->invoice->getDetail('invoice_number') ?? crc32($this->invoice->getUuid()),
-                'Amount'=> $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+                'Amount'=> $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
                 'RedirectUrl'=>$this->settings->callbackUrl,
             ]]);
 

--- a/src/Drivers/Idpay/Idpay.php
+++ b/src/Drivers/Idpay/Idpay.php
@@ -84,7 +84,7 @@ class Idpay extends Driver
 
         $data = array(
             'order_id' => $this->invoice->getUuid(),
-            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1), // convert to rial
             'name' => $details['name'] ?? null,
             'phone' => $phone,
             'mail' => $mail,

--- a/src/Drivers/Irankish/Irankish.php
+++ b/src/Drivers/Irankish/Irankish.php
@@ -78,7 +78,7 @@ class Irankish extends Driver
         $pubKey = $this->settings->pubKey;
         $terminalID = $this->settings->terminalId;
         $password = $this->settings->password;
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         $token = $this->generateAuthenticationEnvelope($pubKey, $terminalID, $password, $amount);
 

--- a/src/Drivers/Nextpay/Nextpay.php
+++ b/src/Drivers/Nextpay/Nextpay.php
@@ -62,7 +62,7 @@ class Nextpay extends Driver
         $data = [
             'api_key' => $this->settings->merchantId,
             'order_id' => intval(1, time()) . crc32($this->invoice->getUuid()),
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'callback_uri' => $this->settings->callbackUrl,
         ];
 
@@ -141,7 +141,7 @@ class Nextpay extends Driver
         $data = [
             'api_key' => $this->settings->merchantId,
             'order_id' => Request::input('order_id'),
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'trans_id' => $transactionId,
         ];
 

--- a/src/Drivers/Omidpay/Omidpay.php
+++ b/src/Drivers/Omidpay/Omidpay.php
@@ -67,7 +67,7 @@ class Omidpay extends Driver
             'TransType' => 'EN_GOODS',
             'ReserveNum' => $this->invoice->getUuid(),
             'MerchantId' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'RedirectUrl' => $this->settings->callbackUrl,
         );
 

--- a/src/Drivers/Parsian/Parsian.php
+++ b/src/Drivers/Parsian/Parsian.php
@@ -169,7 +169,7 @@ class Parsian extends Driver
 
         return array(
             'LoginAccount'      => $this->settings->merchantId,
-            'Amount'            => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount'            => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'OrderId'           => crc32($this->invoice->getUuid()),
             'CallBackUrl'       => $this->settings->callbackUrl,
             'AdditionalData'    => $description,

--- a/src/Drivers/Pasargad/Pasargad.php
+++ b/src/Drivers/Pasargad/Pasargad.php
@@ -104,7 +104,7 @@ class Pasargad extends Driver
                 'TransactionReferenceID' => Request::input('tref')
             ]
         );
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
         if ($amount != $invoiceDetails['Amount']) {
             throw new InvalidPaymentException('Invalid amount');
         }
@@ -197,7 +197,7 @@ class Pasargad extends Driver
         $action = 1003; // 1003 : for buy request (bank standard)
         $merchantCode = $this->settings->merchantId;
         $terminalCode = $this->settings->terminalCode;
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
         $redirectAddress = $this->settings->callbackUrl;
         $invoiceNumber = crc32($this->invoice->getUuid()) . rand(0, time());
 

--- a/src/Drivers/Payfa/Payfa.php
+++ b/src/Drivers/Payfa/Payfa.php
@@ -65,7 +65,7 @@ class Payfa extends Driver
         $cardNumber = $this->extractDetails('cardNumber');
 
         $data = array(
-            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'callbackUrl' => $this->settings->callbackUrl,
             'mobileNumber' => $mobile,
             'invoiceId' => $this->invoice->getUuid(),

--- a/src/Drivers/Payir/Payir.php
+++ b/src/Drivers/Payir/Payir.php
@@ -75,7 +75,7 @@ class Payir extends Driver
 
         $data = array(
             'api' => $this->settings->merchantId,
-            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'redirect' => $this->settings->callbackUrl,
             'mobile' => $mobile,
             'description' => $description,

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -76,7 +76,7 @@ class Payping extends Driver
 
         $data = array(
             "payerName" => $name,
-            "amount" => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            "amount" => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             "payerIdentity" => $mobile ?? $email,
             "returnUrl" => $this->settings->callbackUrl,
             "description" => $description,
@@ -139,7 +139,7 @@ class Payping extends Driver
     {
         $refId = Request::input('refid');
         $data = [
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'refId'  => $refId,
         ];
 

--- a/src/Drivers/Paystar/Paystar.php
+++ b/src/Drivers/Paystar/Paystar.php
@@ -68,7 +68,7 @@ class Paystar extends Driver
     {
         $details = $this->invoice->getDetails();
         $order_id = $this->invoice->getUuid();
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
         $callback = $this->settings->callbackUrl;
 
         $data = [

--- a/src/Drivers/Poolam/Poolam.php
+++ b/src/Drivers/Poolam/Poolam.php
@@ -58,7 +58,7 @@ class Poolam extends Driver
      */
     public function purchase()
     {
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         $data = array(
             'api_key' => $this->settings->merchantId,

--- a/src/Drivers/Rayanpay/Rayanpay.php
+++ b/src/Drivers/Rayanpay/Rayanpay.php
@@ -105,7 +105,7 @@ class Rayanpay extends Driver
             $mobile = '';
         }
 
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1); // convert to rial
 
         if ($amount <= 10000) {
             throw new PurchaseFailedException('مقدار مبلغ ارسالی بزگتر از 10000 ریال باشد.');

--- a/src/Drivers/SEP/SEP.php
+++ b/src/Drivers/SEP/SEP.php
@@ -64,7 +64,7 @@ class SEP extends Driver
         $data = array(
             'action' => 'token',
             'TerminalId' => $this->settings->terminalId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'ResNum' => $this->invoice->getUuid(),
             'RedirectUrl' => $this->settings->callbackUrl,
             'CellNumber' => $this->invoice->getDetail('mobile') ?? '',

--- a/src/Drivers/Sadad/Sadad.php
+++ b/src/Drivers/Sadad/Sadad.php
@@ -63,7 +63,7 @@ class Sadad extends Driver
     {
         $terminalId = $this->settings->terminalId;
         $orderId = crc32($this->invoice->getUuid());
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
         $key = $this->settings->key;
 
         $signData = $this->encrypt_pkcs7("$terminalId;$orderId;$amount", $key);
@@ -113,7 +113,7 @@ class Sadad extends Driver
             }
 
             // convert to rial
-            if ($this->settings->currency == 'T') {
+            if (($this->settings->currency ?? 'T') == 'T') {
                 $multiIdentityRows = array_map(function ($item) {
                     $item['Amount'] = $item['Amount'] * 10;
                     return $item;

--- a/src/Drivers/Saman/Saman.php
+++ b/src/Drivers/Saman/Saman.php
@@ -53,7 +53,7 @@ class Saman extends Driver
         $data = array(
             'MID' => $this->settings->merchantId,
             'ResNum' => $this->invoice->getUuid(),
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'CellNumber' => ''
         );
 

--- a/src/Drivers/Sepehr/Sepehr.php
+++ b/src/Drivers/Sepehr/Sepehr.php
@@ -50,7 +50,7 @@ class Sepehr extends Driver
      */
     public function purchase()
     {
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         $mobile = '';
         //set CellNumber for get user cards
@@ -105,7 +105,7 @@ class Sepehr extends Driver
     public function verify(): ReceiptInterface
     {
         $resp_code = Request::input('respcode');
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         if ($resp_code != 0) {
             $this->notVerified($resp_code);

--- a/src/Drivers/Sepordeh/Sepordeh.php
+++ b/src/Drivers/Sepordeh/Sepordeh.php
@@ -65,7 +65,7 @@ class Sepordeh extends Driver
 
         $data = [
             "merchant" => $this->settings->merchantId,
-            "amount" => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            "amount" => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             "phone" => $phone,
             "orderId" => $orderId,
             "callback" => $this->settings->callbackUrl,

--- a/src/Drivers/Sizpay/Sizpay.php
+++ b/src/Drivers/Sizpay/Sizpay.php
@@ -65,7 +65,7 @@ class Sizpay extends Driver
             'TerminalID' => $this->settings->terminal,
             'UserName' => $this->settings->username,
             'Password' => $this->settings->password,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'R') == 'T' ? 10 : 1), // convert to rial
             'OrderID' => time(),
             'ReturnURL' => $this->settings->callbackUrl,
             'InvoiceNo' => time(),

--- a/src/Drivers/Vandar/Vandar.php
+++ b/src/Drivers/Vandar/Vandar.php
@@ -70,7 +70,7 @@ class Vandar extends Driver
 
         $data = [
             'api_key' => $this->settings->merchantId,
-            'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
+            'amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'callback_url' => $this->settings->callbackUrl,
             'description' => $description,
             'mobile_number' => $mobile,

--- a/src/Drivers/Zarinpal/Strategies/Normal.php
+++ b/src/Drivers/Zarinpal/Strategies/Normal.php
@@ -77,7 +77,7 @@ class Normal extends Driver
 
         $data = [
             "merchant_id" => $this->settings->merchantId,
-            "amount" => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
+            "amount" => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             "callback_url" => $this->settings->callbackUrl,
             "description" => $description,
             "metadata" => array_merge($this->invoice->getDetails() ?? [], $metadata),

--- a/src/Drivers/Zarinpal/Strategies/Normal.php
+++ b/src/Drivers/Zarinpal/Strategies/Normal.php
@@ -77,7 +77,7 @@ class Normal extends Driver
 
         $data = [
             "merchant_id" => $this->settings->merchantId,
-            "amount" => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            "amount" => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             "callback_url" => $this->settings->callbackUrl,
             "description" => $description,
             "metadata" => array_merge($this->invoice->getDetails() ?? [], $metadata),
@@ -138,7 +138,7 @@ class Normal extends Driver
         $data = [
             "merchant_id" => $this->settings->merchantId,
             "authority" => $authority,
-            "amount" => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            "amount" => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
         ];
 
         $response = $this->client->request(

--- a/src/Drivers/Zarinpal/Strategies/Sandbox.php
+++ b/src/Drivers/Zarinpal/Strategies/Sandbox.php
@@ -66,7 +66,7 @@ class Sandbox extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Sandbox extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to rial
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);

--- a/src/Drivers/Zarinpal/Strategies/Sandbox.php
+++ b/src/Drivers/Zarinpal/Strategies/Sandbox.php
@@ -66,7 +66,7 @@ class Sandbox extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Sandbox extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);

--- a/src/Drivers/Zarinpal/Strategies/Zaringate.php
+++ b/src/Drivers/Zarinpal/Strategies/Zaringate.php
@@ -66,7 +66,7 @@ class Zaringate extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Zaringate extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / (($this->settings->currency ?? 'T') == 'T' ? 1 : 10), // convert to toman
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);

--- a/src/Drivers/Zarinpal/Strategies/Zaringate.php
+++ b/src/Drivers/Zarinpal/Strategies/Zaringate.php
@@ -66,7 +66,7 @@ class Zaringate extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Zaringate extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1), // convert to rial
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);

--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -60,7 +60,7 @@ class Zibal extends Driver
     {
         $details = $this->invoice->getDetails();
 
-        $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // convert to rial
+        $amount = $this->invoice->getAmount() * (($this->settings->currency ?? 'T') == 'T' ? 10 : 1); // convert to rial
 
         $orderId = crc32($this->invoice->getUuid()).time();
         if (!empty($details['orderId'])) {


### PR DESCRIPTION
<div dir="rtl">
پول ریکوئست #196 متغیر جدیدی را به فایل کانفیگ اضافه کرده به عنوان currency که باعث شده اپلیکیشن هایی که این متغیر داخل کانفیگشون اضافه نکردند دچار مشکل بشوند.
توی این پول ریکوئست این مشکل با استفاده از عملگر `??` برطرف شده و در صورتیکه اپلیکیشنی این متغیر را مقداردهی نکرده باشه به صورت دیفالت این متغیر مقدار دهی خواهد شد. 

مورد دوم این هست که در درگاه زرین پال مقدار تراکنش به ریال تبدیل شده که اشتباه هست. مطابق داکیومنت زرین پال به لینک https://codeload.github.com/ZarinPal-Lab/Documentation-PaymentGateway/zip/refs/heads/master در ورژن سواپ که این پکیج از آن استفاده میکنه مقدار تراکتش باید به صورت تومان به وب سرویس ارسال شود که به اشتباه به صورت ریال ارسال میگردید. و این مورد نیز اصلاح شد.

در ورژن ۴ وب سرویس زرین پال مقدار ارسالی باید به صورت ریال باشد.
</div>