### PR TITLE
Fix zaringate and sandbox currencies

### DIFF
--- a/src/Drivers/Zarinpal/Strategies/Normal.php
+++ b/src/Drivers/Zarinpal/Strategies/Normal.php
@@ -78,6 +78,7 @@ class Normal extends Driver
         $data = [
             "merchant_id" => $this->settings->merchantId,
             "amount" => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            "currency" => 'IRR',
             "callback_url" => $this->settings->callbackUrl,
             "description" => $description,
             "metadata" => array_merge($this->invoice->getDetails() ?? [], $metadata),

--- a/src/Drivers/Zarinpal/Strategies/Sandbox.php
+++ b/src/Drivers/Zarinpal/Strategies/Sandbox.php
@@ -66,7 +66,7 @@ class Sandbox extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Sandbox extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);

--- a/src/Drivers/Zarinpal/Strategies/Zaringate.php
+++ b/src/Drivers/Zarinpal/Strategies/Zaringate.php
@@ -66,7 +66,7 @@ class Zaringate extends Driver
 
         $data = array(
             'MerchantID' => $this->settings->merchantId,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
             'CallbackURL' => $this->settings->callbackUrl,
             'Description' => $description,
             'Mobile' => $mobile ?? '',
@@ -117,7 +117,7 @@ class Zaringate extends Driver
         $data = [
             'MerchantID' => $this->settings->merchantId,
             'Authority' => $authority,
-            'Amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1), // convert to rial
+            'Amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
         ];
 
         $client = new \SoapClient($this->getVerificationUrl(), ['encoding' => 'UTF-8']);


### PR DESCRIPTION
طبق صحبت‌هایی که اینجا زده شد (https://github.com/shetabit/multipay/pull/196) و طبق مقدار قبلی که بوده (https://github.com/shetabit/multipay/pull/196/commits/de7a1d850a369c4c2f97d69c5a024497609398e8#diff-4d66250a162e69f366657eaf26985d035d3aab8d7d92b362a4cce6608573b871) به نظر میاد توی درگاه زرین پال mode های zaringate و sandbox واحد قیمتی‌شون تومان هست ولی برای normal همون ریال اکی هستش و برای اطمینان بیشتر currency هم طبق مستندات (https://www.zarinpal.com/docs/paymentGateway/connectToGateway.html) فرستاده میشه.