### PR TITLE
Fix: order ID is returned instead of reference ID in Zibal

### DIFF
--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -185,7 +185,7 @@ class Zibal extends Driver
             var_dump($body);
         */
 
-        return $this->createReceipt($orderId);
+        return $this->createReceipt($body->refNumber);
     }
 
     /**


### PR DESCRIPTION
[Fixed the bug described in issues 203](https://github.com/shetabit/multipay/issues/203)