### PR TITLE
Store all details given by Zarinpal payment verification Rest API

### DIFF
--- a/src/Drivers/Zarinpal/Strategies/Normal.php
+++ b/src/Drivers/Zarinpal/Strategies/Normal.php
@@ -161,7 +161,21 @@ class Normal extends Driver
             throw new InvalidPaymentException($this->translateStatus($bodyResponse), $bodyResponse);
         }
 
-        return $this->createReceipt($result['data']['ref_id']);
+        $refId = $result['data']['ref_id'];
+
+        $receipt =  $this->createReceipt($refId);
+        $receipt->detail([
+            'code' => $result['data']['code'],
+            'message' => $result['data']['message'] ?? null,
+            'card_hash' => $result['data']['card_hash'] ?? null,
+            'card_pan' => $result['data']['card_pan'] ?? null,
+            'ref_id' => $refId,
+            'fee_type' => $result['data']['fee_type'] ?? null,
+            'fee' => $result['data']['fee'] ?? null,
+            'order_id' => $result['data']['order_id'] ?? null,
+        ]);
+
+        return $receipt;
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Store details such as `card_pan`, `card_hash`, `fee`, `fee_type`, `order_id` and `message` in payment verification method of Zarinpal normal API

## Motivation and context

It stores the information returned by Zarinpal so that the clients could use those.

## How has this been tested?

These changes are based on the [Zarinpal docuementation](https://www.zarinpal.com/docs/paymentGateway/connectToGateway.html#%D8%A7%D8%B9%D8%AA%D8%A8%D8%A7%D8%B1-%D8%B3%D9%86%D8%AC%DB%8C).

Tests are done with real payments in which the details of the payments mentioned above are returned by `verify` method of `Shetabit\Payment\Facade\Payment` class.

## Screenshots (if appropriate)

![pull-request](https://github.com/shetabit/multipay/assets/25514831/9ae6f1dd-17de-483b-99e5-b8e6c9cd6e20)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
