### PR TITLE
the settings property must be an object, not an array.

### DIFF
--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -52,7 +52,7 @@ class Digipay extends Driver
     public function __construct(Invoice $invoice, $settings)
     {
         $this->invoice($invoice);
-        $this->settings=$settings;
+        $this->settings= (object) $settings;
         $this->client = new Client();
         $this->oauthToken = $this->oauth();
     }


### PR DESCRIPTION
In all drivers, there is a property called settings that should be an object. All drivers treat it as an object. But, in the digipay driver, the cast operation is missing in the constructor. 

i cast settings property to object inside __construct.

I have pushed the fix to a new branch called fix-digipay-settings-type.