### PR TITLE
[feat] add magic method __call to call custom method of driver

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -377,4 +377,22 @@ class Payment
             throw new \Exception("Driver must be an instance of Contracts\DriverInterface.");
         }
     }
+
+    /**
+     *  Call methods of driver instance.
+     *
+     * @throws InvoiceNotFoundException
+     * @throws \Exception
+     */
+    public function __call(string $method_name, array $arguments)
+    {
+        $this->driverInstance = $this->getDriverInstance();
+        $this->validateInvoice();
+
+        if (! method_exists($this->driverInstance, $method_name)) {
+            throw new \Exception("Method $method_name not found in " . get_class($this->driverInstance));
+        }
+
+        return call_user_func_array([$this->driverInstance, $method_name], $arguments);
+    }
 }


### PR DESCRIPTION
Hi,

This pull request adds the magic method `__call` to `Shetabit\Multipay\Payment` to enable the calling of custom methods of drivers. 

I think it solves issue #179. This enhancement allows us to add other custom methods to other drivers.

Usage example:

```php
$payment = Payment::via('digipay')
    ->detail([
        'type'          => 13,
        'providerId'    => '855443ff-418f-44ad-8fbf-a7a5c1ffd0c9',
        'trackingCode'  => '4405940631710064990882',
        'invoiceNumber' => '12121',
        'deliveryDate'  => '2024-03-01',
        'products'      => [
            'test',
        ],
    ]);

dd($payment->deliver());
```

`deliver` is a public method of the Digipay gateway.

If further description or clarification is needed, please let me know.