### PR TITLE
Add Custom Methods to Digipay Gateway 

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -75,9 +75,7 @@ return [
             'cumulativeDynamicPayStatus' => false,
         ],
         'digipay' => [
-            'apiOauthUrl' => 'https://api.mydigipay.com/digipay/api/oauth/token',
-            'apiPurchaseUrl' => 'https://api.mydigipay.info/digipay/api/tickets/business',
-            'apiVerificationUrl' => 'https://api.mydigipay.com/digipay/api/purchases/verify/',
+            'apiPaymentUrl' => 'https://api.mydigipay.com', // with out '/' at the end
             'username' => 'username',
             'password' => 'password',
             'client_id' => '',

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -120,13 +120,14 @@ class Digipay extends Driver
                 ]
             );
 
+        $body = json_decode($response->getBody()->getContents(), true);
+
         if ($response->getStatusCode() != 200) {
             // error has happened
             $message = $body['result']['message'] ?? 'خطا در هنگام درخواست برای پرداخت رخ داده است.';
             throw new PurchaseFailedException($message);
         }
 
-        $body = json_decode($response->getBody()->getContents(), true);
         $this->invoice->transactionId($body['ticket']);
         $this->setPaymentUrl($body['redirectUrl']);
 
@@ -163,13 +164,12 @@ class Digipay extends Driver
             ]
         );
 
-        if ($response->getStatusCode() != 200) {
-            $message = 'تراکنش تایید نشد';
+        $body = json_decode($response->getBody()->getContents(), true);
 
+        if ($response->getStatusCode() != 200) {
+            $message = $body['result']['message'] ?? 'تراکنش تایید نشد';
             throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
-
-        $body = json_decode($response->getBody()->getContents(), true);
 
         return (new Receipt('digipay', $body["trackingCode"]))->detail($body);
     }

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -17,6 +17,13 @@ use Shetabit\Multipay\Request;
 
 class Digipay extends Driver
 {
+    const VERSION      = '2022-02-02';
+    const OAUTH_URL    = '/digipay/api/oauth/token';
+    const PURCHASE_URL = '/digipay/api/tickets/business';
+    const VERIFY_URL   = '/digipay/api/purchases/verify/';
+    const REVERSE_URL  = '/digipay/api/reverse';
+    const DELIVER_URL  = '/digipay/api/purchases/deliver';
+
     /**
      * Digipay Client.
      *
@@ -106,7 +113,7 @@ class Digipay extends Driver
             ->client
             ->request(
                 'POST',
-                $this->settings->apiPurchaseUrl,
+                $this->settings->apiPaymentUrl . self::PURCHASE_URL,
                 [
                     RequestOptions::BODY  => json_encode($data),
                     RequestOptions::QUERY  => ['type' => $digipayType],
@@ -114,7 +121,7 @@ class Digipay extends Driver
                         'Agent' => $this->invoice->getDetail('agent') ?? 'WEB',
                         'Content-Type'  => 'application/json',
                         'Authorization' => 'Bearer ' . $this->oauthToken,
-                        'Digipay-Version' => '2022-02-02',
+                        'Digipay-Version' => self::VERSION,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
                 ]
@@ -153,7 +160,7 @@ class Digipay extends Driver
 
         $response = $this->client->request(
             'POST',
-            $this->settings->apiVerificationUrl . $tracingId,
+            $this->settings->apiPaymentUrl . self::VERIFY_URL . $tracingId,
             [
                 RequestOptions::QUERY      => ['type' => $digipayTicketType],
                 RequestOptions::HEADERS    => [
@@ -183,7 +190,7 @@ class Digipay extends Driver
             ->client
             ->request(
                 'POST',
-                $this->settings->apiOauthUrl,
+                $this->settings->apiPaymentUrl . self::OAUTH_URL,
                 [
                     RequestOptions::HEADERS   => [
                         'Authorization' => 'Basic ' . base64_encode("{$this->settings->client_id}:{$this->settings->client_secret}"),

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -421,12 +421,12 @@ class Digipay extends Driver
         return $body;
     }
 
-    public function getPaymentUrl(): string
+    private function getPaymentUrl(): string
     {
         return $this->paymentUrl;
     }
 
-    public function setPaymentUrl(string $paymentUrl): void
+    private function setPaymentUrl(string $paymentUrl): void
     {
         $this->paymentUrl = $paymentUrl;
     }

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -67,7 +67,7 @@ class Digipay extends Driver
     public function __construct(Invoice $invoice, $settings)
     {
         $this->invoice($invoice);
-        $this->settings = (object)$settings;
+        $this->settings = (object) $settings;
         $this->client = new Client();
         $this->oauthToken = $this->oauth();
     }
@@ -267,7 +267,7 @@ class Digipay extends Driver
 
         if ($response->getStatusCode() != 200 || $body['result']['code'] != 0) {
             $message = $body['result']['message'] ?? 'خطا در هنگام درخواست برای برگشت وجه رخ داده است.';
-            throw new InvalidPaymentException($message, (int)$response->getStatusCode());
+            throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
         return $body;
@@ -339,7 +339,7 @@ class Digipay extends Driver
 
         if ($response->getStatusCode() != 200 || $body['result']['code'] != 0) {
             $message = $body['result']['message'] ?? 'خطا در هنگام درخواست برای تحویل کالا رخ داده است.';
-            throw new InvalidPaymentException($message, (int)$response->getStatusCode());
+            throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
         return $body;
@@ -363,7 +363,7 @@ class Digipay extends Driver
 
         if ($response->getStatusCode() != 200 || $body['result']['code'] != 0) {
             $message = $body['result']['message'] ?? 'خطا در هنگام درخواست برای دریافت تنظیمات مرجوعی رخ داده است.';
-            throw new InvalidPaymentException($message, (int)$response->getStatusCode());
+            throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
         $certFile = $response['certFile'];
@@ -415,7 +415,7 @@ class Digipay extends Driver
 
         if ($response->getStatusCode() != 200 || $body['result']['code'] != 0) {
             $message = $body['result']['message'] ?? 'خطا در هنگام درخواست مرجوعی تراکنش رخ داده است.';
-            throw new InvalidPaymentException($message, (int)$response->getStatusCode());
+            throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
         return $body;


### PR DESCRIPTION
Hi,

This pull request adds two custom methods to the Digipay Gateway:

- [Purchase Reverse](https://docs.mydigipay.com/upg.html#_purchase_reverse)
- [Purchase Delivery](https://docs.mydigipay.com/upg.html#_purchase_delivery)

Additionally, only the base URL is defined in the config file, while sub-URLs are added as constants in the class.

This pull request should be merged after #230.