### PR TITLE
Get transaction token from user's config instead of POST method

### DIFF
--- a/src/Drivers/Parsian/Parsian.php
+++ b/src/Drivers/Parsian/Parsian.php
@@ -104,9 +104,9 @@ class Parsian extends Driver
     public function verify() : ReceiptInterface
     {
         $status = Request::input('status');
-        $token = Request::input('Token');
+        $token = $this->invoice->getTransactionId() ?? Request::input('Token');
 
-        if ($status != 0 || empty($token)) {
+        if (empty($token)) {
             throw new InvalidPaymentException('تراکنش توسط کاربر کنسل شده است.', (int)$status);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This request is created because when we use the Parsian gateway as an API, the response we receive is always a canceled user response.
While the transaction is successfully carried out, upon further investigation, I found a line of code that retrieves the token from the POST method, even though we had set the token in the config. By modifying this line, no more errors are displayed, and the issue is resolved.
## Motivation and context

I update this line:
`$token = Request::input('Token')`
to
`$token = $this->invoice->getTransactionId() ?? Request::input('Token');`

Now if user set transaction_id from config, we go to next step.

issu link: https://github.com/shetabit/multipay/issues/243
`fixes #243`

