### PR TITLE
Add `Snapp Pay` driver

### DIFF
--- a/README-FA.md
+++ b/README-FA.md
@@ -82,6 +82,7 @@
 - [سپهر (صادرات)](https://www.sepehrpay.com/) :heavy_check_mark:
 - [سپرده](https://sepordeh.com/) :heavy_check_mark:
 - [سیزپی](https://www.sizpay.ir/) :heavy_check_mark:
+- [اسنپ‌پی](https://snapppay.ir/) :heavy_check_mark:
 - [تومن](https://tomanpay.net/) :heavy_check_mark:
 - [وندار](https://vandar.io/) :heavy_check_mark:
 - [والتا](https://walleta.ir/) :heavy_check_mark:

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -81,6 +81,7 @@ For **Laravel** integration you can use [shetabit/payment](https://github.com/sh
 - [sepordeh](https://sepordeh.com/) :heavy_check_mark:
 - [sizpay](https://www.sizpay.ir/) :heavy_check_mark:
 - [toman](https://tomanpay.net/) :heavy_check_mark:
+- [snapppay](https://snapppay.ir/) :heavy_check_mark:
 - [vandar](https://vandar.io/) :heavy_check_mark:
 - [walleta (Installment payment)](https://walleta.ir/) :heavy_check_mark:
 - [yekpay](https://yekpay.com/) :heavy_check_mark:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For **Laravel** integration you can use [shetabit/payment](https://github.com/sh
 - [sepehr (saderat)](https://www.sepehrpay.com/) :heavy_check_mark:
 - [sepordeh](https://sepordeh.com/) :heavy_check_mark:
 - [sizpay](https://www.sizpay.ir/) :heavy_check_mark:
+- [snapppay](https://snapppay.ir/) :heavy_check_mark:
 - [toman](https://tomanpay.net/) :heavy_check_mark:
 - [vandar](https://vandar.io/) :heavy_check_mark:
 - [walleta (Installment payment)](https://walleta.ir/) :heavy_check_mark:

--- a/config/payment.php
+++ b/config/payment.php
@@ -434,7 +434,7 @@ return [
             'description' => 'payment using Minipay.',
             'currency' => 'T', //Can be R, T (Rial, Toman)
         ],
-        'snapppay'=>[
+        'snapppay' => [
             'apiPaymentUrl' => 'https://fms-gateway-staging.apps.public.teh-1.snappcloud.io',
             'callbackUrl' => 'http://yoursite.com/path/to',
             'username' => 'username',
@@ -497,6 +497,6 @@ return [
         'toman' => \Shetabit\Multipay\Drivers\Toman\Toman::class,
         'bitpay' => \Shetabit\Multipay\Drivers\Bitpay\Bitpay::class,
         'minipay' => \Shetabit\Multipay\Drivers\Minipay\Minipay::class,
-        'snapppay'=>\Shetabit\Multipay\Drivers\SnappPay\SnappPay::class,
+        'snapppay'=> \Shetabit\Multipay\Drivers\SnappPay\SnappPay::class,
     ]
 ];

--- a/config/payment.php
+++ b/config/payment.php
@@ -434,6 +434,16 @@ return [
             'description' => 'payment using Minipay.',
             'currency' => 'T', //Can be R, T (Rial, Toman)
         ],
+        'snapppay'=>[
+            'apiPaymentUrl' => 'https://fms-gateway-staging.apps.public.teh-1.snappcloud.io',
+            'callbackUrl' => 'http://yoursite.com/path/to',
+            'username' => 'username',
+            'password' => 'password',
+            'client_id' => '',
+            'client_secret' => '',
+            'description' => 'payment using Snapp Pay.',
+            'currency' => 'T', //Can be R, T (Rial, Toman)
+        ],
     ],
 
     /*
@@ -487,5 +497,6 @@ return [
         'toman' => \Shetabit\Multipay\Drivers\Toman\Toman::class,
         'bitpay' => \Shetabit\Multipay\Drivers\Bitpay\Bitpay::class,
         'minipay' => \Shetabit\Multipay\Drivers\Minipay\Minipay::class,
+        'snapppay'=>\Shetabit\Multipay\Drivers\SnappPay\SnappPay::class,
     ]
 ];

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -266,7 +266,6 @@ class SnappPay extends Driver
                 $cartItem['amount'] = $this->normalizerAmount($cartItem['amount']);
             }
         }
-
     }
 
     public function settle(): array
@@ -357,7 +356,6 @@ class SnappPay extends Driver
         }
 
         return $body['response'];
-
     }
 
     public function cancel()
@@ -388,7 +386,6 @@ class SnappPay extends Driver
         }
 
         return $body['response'];
-
     }
 
     public function update()

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -1,0 +1,251 @@
+<?php
+
+
+namespace Shetabit\Multipay\Drivers\SnappPay;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Shetabit\Multipay\Abstracts\Driver;
+use Shetabit\Multipay\Contracts\ReceiptInterface;
+use Shetabit\Multipay\Exceptions\InvalidPaymentException;
+use Shetabit\Multipay\Exceptions\PurchaseFailedException;
+use Shetabit\Multipay\Invoice;
+use Shetabit\Multipay\RedirectionForm;
+
+class SnappPay extends Driver
+{
+    const VERSION = '1.8';
+    const RELEASE_DATE = '2023-01-08';
+
+    const OAUTH_URL = '/api/online/v1/oauth/token';
+    const ELIGIBLE_URL = '/api/online/offer/v1/eligible';
+    const TOKEN_URL = '/api/online/payment/v1/token';
+    const VERIFY_URL = '/api/online/payment/v1/verify';
+    const SETTLE_URL = '/api/online/payment/v1/settle';
+    const REVERT_URL = '/api/online/payment/v1/revert';
+    const STATUS_URL = '/api/online/payment/v1/status';
+    const CANCEL_URL = '/api/online/payment/v1/cancel';
+    const UPDATE_URL = '/api/online/payment/v1/update';
+
+    /**
+     * SnappPay Client.
+     *
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Invoice
+     *
+     * @var Invoice
+     */
+    protected $invoice;
+
+    /**
+     * Driver settings
+     *
+     * @var object
+     */
+    protected $settings;
+    /**
+     * SnappPay Oauth Data
+     *
+     * @var string
+     */
+    protected $oauthToken;
+
+    /**
+     * SnappPay payment url
+     *
+     * @var string
+     */
+    protected $paymentUrl;
+
+    /**
+     * SnappPay constructor.
+     * Construct the class with the relevant settings.
+     */
+    public function __construct(Invoice $invoice, $settings)
+    {
+        $this->invoice($invoice);
+        $this->settings = (object) $settings;
+        $this->client = new Client();
+        $this->oauthToken = $this->oauth();
+    }
+
+    /**
+     * @throws PurchaseFailedException
+     */
+    public function purchase(): string
+    {
+        $phone = $this->invoice->getDetail('phone')
+            ?? $this->invoice->getDetail('cellphone')
+            ?? $this->invoice->getDetail('mobile');
+
+        $data = [
+            'amount' => $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1),
+            'mobile' => $phone,
+            'paymentMethodTypeDto' => 'INSTALLMENT',
+            'transactionId' => $this->invoice->getUuid(),
+            'returnURL' => $this->settings->callbackUrl,
+        ];
+
+        if (!is_null($discountAmount = $this->invoice->getDetail('discountAmount'))) {
+            $data['discountAmount'] = $discountAmount;
+        }
+
+        if (!is_null($externalSourceAmount = $this->invoice->getDetail('externalSourceAmount'))) {
+            $data['externalSourceAmount'] = $externalSourceAmount;
+        }
+
+        if (!is_null($cartList = $this->invoice->getDetail('cartList'))) {
+            $data['cartList'] = $cartList;
+        }
+
+        $response = $this
+            ->client
+            ->post(
+                $this->settings->apiPaymentUrl.self::TOKEN_URL,
+                [
+                    RequestOptions::FORM_PARAMS => $data,
+                    RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
+                        'Authorization' => 'Bearer '.$this->oauthToken,
+                    ],
+                    RequestOptions::HTTP_ERRORS => false,
+                ]
+            );
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        if ($response->getStatusCode() != 200 || $body['successful'] == false) {
+            // error has happened
+            $message = 'خطا در هنگام درخواست برای پرداخت رخ داده است.';
+            throw new PurchaseFailedException($message);
+        }
+
+        $this->invoice->transactionId($body['response']['paymentToken']);
+        $this->setPaymentUrl($body['response']['paymentPageUrl']);
+
+        // return the transaction's id
+        return $this->invoice->getTransactionId();
+    }
+
+    public function pay(): RedirectionForm
+    {
+        return $this->redirectWithForm($this->getPaymentUrl(), [], 'GET');
+    }
+
+    /**
+     * @throws InvalidPaymentException
+     */
+    public function verify(): ReceiptInterface
+    {
+        $paymentToken = $this->invoice->getTransactionId();
+
+        $response = $this
+            ->client
+            ->post(
+                $this->settings->apiPaymentUrl.self::TOKEN_URL,
+                [
+                    RequestOptions::BODY => [
+                        'paymentToken' => $paymentToken,
+                    ],
+                    RequestOptions::HEADERS => [
+                        'Authorization' => 'Bearer '.$this->oauthToken,
+                    ],
+                    RequestOptions::HTTP_ERRORS => false,
+                ]
+            );
+    }
+
+    /**
+     * @throws PurchaseFailedException
+     */
+    protected function oauth()
+    {
+
+        $response = $this
+            ->client
+            ->post(
+                $this->settings->apiPaymentUrl.self::OAUTH_URL,
+                [
+                    RequestOptions::HEADERS => [
+                        'Authorization' => 'Basic '.base64_encode("{$this->settings->client_id}:{$this->settings->client_secret}"),
+                    ],
+                    RequestOptions::FORM_PARAMS => [
+                        'grant_type' => 'password',
+                        'scope' => 'online-merchant',
+                        'username' => $this->settings->username,
+                        'password' => $this->settings->password,
+                    ],
+                    RequestOptions::HTTP_ERRORS => false,
+                ]
+            );
+
+        if ($response->getStatusCode() != 200) {
+            throw new PurchaseFailedException('خطا در هنگام احراز هویت.');
+        }
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        return $body['access_token'];
+    }
+
+    /**
+     * @throws PurchaseFailedException
+     */
+    public function eligible()
+    {
+        if (is_null($amount = $this->invoice->getDetail('amount'))) {
+            throw new PurchaseFailedException('"amount" is required for this method.');
+        }
+
+        $response = $this->client->get(self::ELIGIBLE_URL, [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer '.$this->oauthToken,
+            ],
+            RequestOptions::QUERY => [
+                'amount' => $amount,
+            ],
+        ]);
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        if ($response->getStatusCode() != 200) {
+            throw new InvalidPaymentException('', (int) $response->getStatusCode());
+        }
+
+        return $body;
+    }
+
+    public function settle()
+    {
+    }
+
+    public function revert()
+    {
+    }
+
+    public function status()
+    {
+    }
+
+    public function cancel()
+    {
+    }
+
+    public function update()
+    {
+    }
+
+    public function getPaymentUrl(): string
+    {
+        return $this->paymentUrl;
+    }
+
+    public function setPaymentUrl(string $paymentUrl): void
+    {
+        $this->paymentUrl = $paymentUrl;
+    }
+}

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -164,7 +164,6 @@ class SnappPay extends Driver
      */
     protected function oauth()
     {
-
         $response = $this
             ->client
             ->post(

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -342,7 +342,7 @@ class SnappPay extends Driver
             ->get(
                 $this->settings->apiPaymentUrl.self::STATUS_URL,
                 [
-                    RequestOptions::BODY => json_encode($data),
+                    RequestOptions::QUERY => $data,
                     RequestOptions::HEADERS => [
                         'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
@@ -442,12 +442,12 @@ class SnappPay extends Driver
         return $body['response'];
     }
 
-    public function getPaymentUrl(): string
+    private function getPaymentUrl(): string
     {
         return $this->paymentUrl;
     }
 
-    public function setPaymentUrl(string $paymentUrl): void
+    private function setPaymentUrl(string $paymentUrl): void
     {
         $this->paymentUrl = $paymentUrl;
     }

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -162,6 +162,7 @@ class SnappPay extends Driver
                 [
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
@@ -281,6 +282,7 @@ class SnappPay extends Driver
                 [
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
@@ -311,6 +313,7 @@ class SnappPay extends Driver
                 [
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
@@ -341,6 +344,7 @@ class SnappPay extends Driver
                 [
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
@@ -371,6 +375,7 @@ class SnappPay extends Driver
                 [
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
+                        'Content-Type' => 'application/json',
                         'Authorization' => 'Bearer '.$this->oauthToken,
                     ],
                     RequestOptions::HTTP_ERRORS => false,


### PR DESCRIPTION
Hi,

This pull request adds the `Snapp Pay` gateway, which facilitates installment payments. When creating a transaction, you need to pass the basket details to the gateway. The image below illustrates a simple basket with the required data.

![Basket Data](https://github.com/shetabit/multipay/assets/26966142/a69bd432-b932-4c01-aca8-7ba2c5f62fb9)

<div dir="rtl">

```
🔹گایدلاین ارسال دیتا در سرویس پیمنت توکن 🔹

➖مقادیر شامل در discountAmount :
کارت هدیه + کد تخفیف + امتیاز کاربر + کوپن

➖مقادیر شامل در externalSourceAmount :
کیف پول کاربر

➖ مقادیر شامل در shippingAmount :
بسته بندی + کادو پیچ + هزینه ارسال + هزینه بسته بندی محرمانه

➖ مقادیر شامل در totalAmount :
حاصل جمع مبالغ آیتم ها با در نظر گرفتن تعداد و هزینه tax و shipping
```
</div>

This driver includes the following methods:

- **eligible**: Ensures that you can offer the credit option to users.
- **settle**: Finalizes the payment after the `verify` method is called.
- **revert**: Refunds the payment to the user if the order cannot be completed (after verify).
- **status**: Retrieves the status of the payment.
- **cancel**: Cancels the payment (after settle).
- **update**: Changes the items in the basket, ensuring the final amount is less than the original amount.

Below is an image showing the process flow:

![Process Flow](https://github.com/shetabit/multipay/assets/26966142/0d9085d4-f839-4b7a-b60b-7a7d0e643ced)

### How has this been tested?
An account was set up in the staging environment of this gateway, and the following methods were tested:

- [x] `oauth/token`
- [x] `eligible`
- [x] `token`
- [x] `verify`
- [ ] `settle`
- [ ] `revert`
- [ ] `status`
- [ ] `cancel`
- [ ] `update`

Thanks.
