### PR TITLE
Fix driver name used for creating SnappPay Receipt

### DIFF
--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -177,7 +177,7 @@ class SnappPay extends Driver
             throw new PurchaseFailedException($message);
         }
 
-        return (new Receipt('digipay', $body['response']['transactionId']))->detail($body['response']);
+        return (new Receipt('snapppay', $body['response']['transactionId']))->detail($body['response']);
     }
 
     /**


### PR DESCRIPTION
SnappPay Receipt is being created with `digipay` driver name. I changed that to `snapppay`.