### PR TITLE
Return response from SnappPay::eligible

### DIFF
--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -232,12 +232,12 @@ class SnappPay extends Driver
 
         $body = json_decode($response->getBody()->getContents(), true);
 
-        if ($response->getStatusCode() != 200) {
+        if ($response->getStatusCode() != 200 || $body['successful'] === false) {
             $message = $body['errorData']['message'] ?? 'خطا در هنگام درخواست برای پرداخت رخ داده است.';
             throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
-        return $body;
+        return $body['response'];
     }
 
     private function normalizerAmount(int $amount): int


### PR DESCRIPTION
Currently, all SnappPay endpoints **except `/oauth/token`** have a specific JSON structure in their response as below:
```
{
    "response": {},
    "successful": true
}
```

The SnappPay driver implemented in this project has followed this structure and is checking the `successful` boolean property first (throwing an exception if it's false), then returning the `response` property as result in all public methods. But this convention has been ignored in the `eligible` method. The `successful` property check is absent, and it's returning the entire json body instead of the `response` property.

I submitted this PR to follow the same convention for returning results in all public methods. I am aware that this change may introduce a breaking change, so please let me know how you handle these kind of inconsistencies.