### PR TITLE
Add Timeout Handling to `verify()` Method with Custom Exception

### DIFF
--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -4,9 +4,11 @@
 namespace Shetabit\Multipay\Drivers\SnappPay;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\RequestOptions;
 use Shetabit\Multipay\Abstracts\Driver;
 use Shetabit\Multipay\Contracts\ReceiptInterface;
+use Shetabit\Multipay\Exceptions\DriverTimeoutException;
 use Shetabit\Multipay\Exceptions\InvalidPaymentException;
 use Shetabit\Multipay\Exceptions\PurchaseFailedException;
 use Shetabit\Multipay\Invoice;
@@ -147,7 +149,8 @@ class SnappPay extends Driver
     }
 
     /**
-     * @throws InvalidPaymentException
+     * @throws DriverTimeoutException
+     * @throws PurchaseFailedException
      */
     public function verify(): ReceiptInterface
     {
@@ -155,29 +158,34 @@ class SnappPay extends Driver
             'paymentToken' => $this->invoice->getTransactionId(),
         ];
 
-        $response = $this
-            ->client
-            ->post(
-                $this->settings->apiPaymentUrl.self::VERIFY_URL,
-                [
-                    RequestOptions::BODY => json_encode($data),
-                    RequestOptions::HEADERS => [
-                        'Content-Type' => 'application/json',
-                        'Authorization' => 'Bearer '.$this->oauthToken,
-                    ],
-                    RequestOptions::HTTP_ERRORS => false,
-                ]
-            );
+        try {
+            $response = $this
+                ->client
+                ->post(
+                    $this->settings->apiPaymentUrl.self::VERIFY_URL,
+                    [
+                        RequestOptions::TIMEOUT => 60, // 1 minute
+                        RequestOptions::BODY => json_encode($data),
+                        RequestOptions::HEADERS => [
+                            'Content-Type' => 'application/json',
+                            'Authorization' => 'Bearer '.$this->oauthToken,
+                        ],
+                        RequestOptions::HTTP_ERRORS => false,
+                    ]
+                );
 
-        $body = json_decode($response->getBody()->getContents(), true);
+            $body = json_decode($response->getBody()->getContents(), true);
 
-        if ($response->getStatusCode() != 200 || $body['successful'] === false) {
-            // error has happened
-            $message = $body['errorData']['message'] ?? 'خطا در هنگام تایید تراکنش';
-            throw new PurchaseFailedException($message);
+            if ($response->getStatusCode() != 200 || $body['successful'] === false) {
+                // error has happened
+                $message = $body['errorData']['message'] ?? 'خطا در هنگام تایید تراکنش';
+                throw new PurchaseFailedException($message);
+            }
+
+            return (new Receipt('snapppay', $body['response']['transactionId']))->detail($body['response']);
+        } catch (ConnectException $exception) {
+            throw new DriverTimeoutException('پاسخی از درگاه دریافت نشد.');
         }
-
-        return (new Receipt('snapppay', $body['response']['transactionId']))->detail($body['response']);
     }
 
     /**

--- a/src/Exceptions/DriverTimeoutException.php
+++ b/src/Exceptions/DriverTimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Shetabit\Multipay\Exceptions;
+
+class DriverTimeoutException extends PurchaseFailedException
+{
+}

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -5,7 +5,9 @@ namespace Shetabit\Multipay;
 use Shetabit\Multipay\Contracts\DriverInterface;
 use Shetabit\Multipay\Contracts\ReceiptInterface;
 use Shetabit\Multipay\Exceptions\DriverNotFoundException;
+use Shetabit\Multipay\Exceptions\DriverTimeoutException;
 use Shetabit\Multipay\Exceptions\InvoiceNotFoundException;
+use Shetabit\Multipay\Exceptions\PurchaseFailedException;
 use Shetabit\Multipay\Traits\HasPaymentEvents;
 use Shetabit\Multipay\Traits\InteractsWithRedirectionForm;
 
@@ -261,6 +263,8 @@ class Payment
      * @return ReceiptInterface
      *
      * @throws InvoiceNotFoundException
+     * @throws PurchaseFailedException
+     * @throws DriverTimeoutException
      */
     public function verify($finalizeCallback = null) : ReceiptInterface
     {


### PR DESCRIPTION
## Description

After meeting with the technical team of **SnappPay**, want to add a timeout of 60 seconds to the `verify()` method. If the timeout is reached, the method should then call `GetPaymentStatus` (handled by the driver's `status()` method) to retrieve the payment status.

To handle this scenario, a new exception named `DriverTimeoutException` has been introduced. This exception extends from `PurchaseFailedException`, ensuring that the existing project logic does not require changes.

Here's an example of how the exception can be used:

```php
// At the top of the file.
use Shetabit\Multipay\Payment;
use Shetabit\Multipay\Exceptions\InvalidPaymentException;
use Shetabit\Multipay\Exceptions\DriverTimeoutException;
use Shetabit\Multipay\Exceptions\PurchaseFailedException;

try {
    $receipt = $payment->amount(1000)->transactionId($transaction_id)->verify();

    echo $receipt->getReferenceId();

    ...
} catch (DriverTimeoutException $exception) {
    echo $exception->getMessage();
} catch (PurchaseFailedException $exception) {
    echo $exception->getMessage();
} catch (InvalidPaymentException $exception) {
    echo $exception->getMessage();
}
```

If `DriverTimeoutException` is not caught, it will be handled by `PurchaseFailedException`.

## How Has This Been Tested?

The method was tested using the `oauth()` function. When the timeout was set to `0.01`, a `GuzzleHttp\Exception\ConnectException` was thrown. When the timeout was set to 2 seconds, a driver-specific error was returned.

Screenshots of the testing process are provided:
![Testing Timeout](https://github.com/user-attachments/assets/c4355a84-5594-4bd0-b7b4-5c1b0b10597d)
![Driver Error](https://github.com/user-attachments/assets/688a60bf-4bc7-4191-a402-ee868188f591)

## Types of Changes

Please put an `x` in the relevant boxes:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)