### PR TITLE
Add additional parameters for SEP gateway

### DIFF
--- a/src/Drivers/SEP/SEP.php
+++ b/src/Drivers/SEP/SEP.php
@@ -174,6 +174,9 @@ class SEP extends Driver
             'OrginalAmount' => $transactionDetail['OrginalAmount'],
             'AffectiveAmount' => $transactionDetail['AffectiveAmount'],
             'StraceDate' => $transactionDetail['StraceDate'],              
+            // SEP documents are not up-to-date. This will fix different 
+            // between variable name in docs and actual returned values.
+            'Amount' => $transactionDetail['OrginalAmount'],                         
         ]);
         
         return $receipt;

--- a/src/Drivers/SEP/SEP.php
+++ b/src/Drivers/SEP/SEP.php
@@ -168,6 +168,14 @@ class SEP extends Driver
             'cardNo' => $transactionDetail['MaskedPan'],
         ]);
 
+        // Add additional data specific for SEP gateway
+        $receipt->detail([
+            'TerminalNumber' => $transactionDetail['TerminalNumber'],
+            'OrginalAmount' => $transactionDetail['OrginalAmount'],
+            'AffectiveAmount' => $transactionDetail['AffectiveAmount'],
+            'StraceDate' => $transactionDetail['StraceDate'],              
+        ]);
+        
         return $receipt;
     }
 


### PR DESCRIPTION
SEP gateway's verify method returns some additional info about the Terminal and Transaction. 
```
TerminalId
OrginalAmount(Amount)
AffectiveAmount
StraceDate
```

## Description

This PR adds all the additional parameters to the receipt. 

## Motivation and context

Using verify will only check for `RefNum` parameter. This feature adds the ability to check for paid amount after verify.
Also if merchant have multiple gateway terminals, the TerminalNumber value can be used to separate payments for different terminals.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
