### PR TITLE
Add PayPing version 3 support

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -246,7 +246,6 @@ return [
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using payping',
             'currency' => 'T', //Can be R, T (Rial, Toman)
-            'version'=>'3'
         ],
         'paystar' => [
             'apiPurchaseUrl' => 'https://core.paystar.ir/api/pardakht/create/',

--- a/config/payment.php
+++ b/config/payment.php
@@ -239,13 +239,14 @@ return [
             'currency' => 'T', //Can be R, T (Rial, Toman)
         ],
         'payping' => [
-            'apiPurchaseUrl' => 'https://api.payping.ir/v2/pay/',
-            'apiPaymentUrl' => 'https://api.payping.ir/v2/pay/gotoipg/',
-            'apiVerificationUrl' => 'https://api.payping.ir/v2/pay/verify/',
+            'apiPurchaseUrl' => 'https://api.payping.ir/v3/pay/',
+            'apiPaymentUrl' => 'https://api.payping.ir/v3/pay/start/',
+            'apiVerificationUrl' => 'https://api.payping.ir/v3/pay/verify/',
             'merchantId' => '',
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using payping',
             'currency' => 'T', //Can be R, T (Rial, Toman)
+            'version'=>'3'
         ],
         'paystar' => [
             'apiPurchaseUrl' => 'https://core.paystar.ir/api/pardakht/create/',

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -108,7 +108,7 @@ class Payping extends Driver
 
             throw new PurchaseFailedException($message);
         }
-        if (!isset($this->settings->version) || $this->settings->version === '2' || $this->settings->version === '1') {
+        if (($this->settings->version??'2')==='2') {
             $this->invoice->transactionId($body['code']);
         }else{
             $this->invoice->transactionId($body['paymentCode']);
@@ -141,7 +141,7 @@ class Payping extends Driver
     public function verify() : ReceiptInterface
     {
         $refId = Request::input('refid');
-        if (!isset($this->settings->version) || $this->settings->version === '2' || $this->settings->version === '1'){
+        if (($this->settings->version??'2')==='2'){
             $data = [
                 'amount' => $this->invoice->getAmount() / ($this->settings->currency == 'T' ? 1 : 10), // convert to toman
                 'refId'  => $refId,

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -48,13 +48,6 @@ class Payping extends Driver
         $this->invoice($invoice);
         $this->settings = (object) $settings;
         $this->client = new Client();
-        if (
-            strpos($this->settings->apiPurchaseUrl,'v3')!==true||
-            strpos($this->settings->apiPaymentUrl,'v3')!==true||
-            strpos($this->settings->apiVerficationUrl,'v3')!==true
-        ){
-            throw new InvalidPaymentException("Invalid Payment API URL");
-        }
     }
 
     /**


### PR DESCRIPTION
از آنجایی که در ورژن ۳ تمامی لینک های مربوط به وب سرویس تغییر کرده است و نام فیلد های برگشتی هم تغییر داشته برای حفظ سازگاری نرم افزار با ورژن های قبلی مجبور هستیم که یک کانفیگ جدید به درایور پی پینگ اضافه کنیم. و بر اساس اون درخواست ها را تغییر بدیم. 

در صورتیکه کاربران ورژن های قبلی قصد دارند به ورژن جدید پی پینگ ارتقا بدن سیستم باید در فایل کانفیگ پارامتر های درایور پی پینگ را به این شکل تغییر بدن
```
            'apiPurchaseUrl' => 'https://api.payping.ir/v3/pay/',
            'apiPaymentUrl' => 'https://api.payping.ir/v3/pay/start/',
            'apiVerificationUrl' => 'https://api.payping.ir/v3/pay/verify/',
            'version'=>'3'
```