### PR TITLE
Add: receipt details to ReceiptInterface

### DIFF
--- a/src/Contracts/ReceiptInterface.php
+++ b/src/Contracts/ReceiptInterface.php
@@ -26,4 +26,17 @@ interface ReceiptInterface
      * @return Carbon
      */
     public function getDate() : Carbon;
+
+    /**
+     * Retrieve detail using its name
+     *
+     * @param $name
+     * @return string|null
+     */
+    public function getDetail($name);
+
+    /**
+     * Get the value of details
+     */
+    public function getDetails() : array;
 }


### PR DESCRIPTION
We have this issue where we don't have access to the receipt details right after verifying payment!

**Motivation for the Change**

1. **Standardization:** These additions align the ReceiptInterface with the Receipt implementation, ensuring all details are accessible through the defined interface methods.
2. **Flexibility:** Provides a built-in way for users to retrieve metadata stored in detail() without requiring dedicated getters for each specific key.
3. **Code Consistency:** Brings parity between the concrete Receipt class (which uses HasDetail) and its contract, making it clear that details and metadata are part of the core functionality.
4. **Improved Usability:** Users can now access and manipulate transaction metadata more easily through methods that adhere to the interface, improving the developer experience.