### PR TITLE
Add Timeout to `eligible` Method in SnappPay

### DIFF
--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -240,6 +240,8 @@ class SnappPay extends Driver
             RequestOptions::QUERY => [
                 'amount' => $this->normalizerAmount($amount),
             ],
+            RequestOptions::HTTP_ERRORS => false,
+            RequestOptions::TIMEOUT => 10, // 10 seconds
         ]);
 
         $body = json_decode($response->getBody()->getContents(), true);

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -212,6 +212,7 @@ class SnappPay extends Driver
                         'password' => $this->settings->password,
                     ],
                     RequestOptions::HTTP_ERRORS => false,
+                    RequestOptions::TIMEOUT => 10, // 10 seconds
                 ]
             );
 


### PR DESCRIPTION
Hi,  

This pull request adds a **10-second timeout** to the `eligible` method of SnappPay. This method is called when a user want selects a payment gateway. 

Previously, if the API connection failed or was slow, the method would hang indefinitely since it had no timeout. Adding a timeout improves reliability and prevents delays in the payment process.  

