### PR TITLE
Fix: Prevent double spending and replay attacks in Saman payment driver

### DIFF
--- a/src/Drivers/Saman/Saman.php
+++ b/src/Drivers/Saman/Saman.php
@@ -146,6 +146,12 @@ class Saman extends Driver
             $this->notVerified($status);
         }
 
+        if ($this->getInvoice()->getTransactionId() !== Request::input('ResNum')){
+            $soap->ReverseTransaction($data["RefNum"], $data["merchantId"], $data["password"], $verifiedAmount);
+            $status = -101;
+            $this->notVerified($status);
+        }
+
         $receipt =  $this->createReceipt($data['RefNum']);
         $receipt->detail([
             'traceNo' => Request::input('TraceNo'),
@@ -229,6 +235,7 @@ class Saman extends Driver
             -17 => 'برگشت زدن جزیی تراکنش مجاز نمی باشد.',
             -18 => 'IP Address فروشنده نا معتبر است و یا رمز تابع بازگشتی (reverseTransaction) اشتباه است.',
             -100 => 'مبلغ برگشتی با مبلغ فاکتور همخوانی ندارد.',
+            -101 => 'اطلاعات پرداخت با فاکتور همخوانی ندارد.',
         ];
 
         if (array_key_exists($status, $translations)) {


### PR DESCRIPTION
Description
Added **transaction ID verification** to the Saman payment driver's verify() method to **prevent double spending and replay attacks**. The implementation compares the stored transaction ID with the 'ResNum' parameter returned from the payment gateway. If they don't match, the transaction is automatically reversed using the ReverseTransaction SOAP method and an appropriate error is thrown with code -101.

Motivation and context
This change is required to address a critical security vulnerability in the payment flow. Without this verification, an attacker could potentially replay a successful payment response or process the same payment multiple times, leading to financial losses.

The implementation prevents these security risks by ensuring that the transaction ID created during the purchase phase matches exactly with what's returned during verification. This ensures that each payment can only be processed once and that the payment response belongs to the correct transaction.


How has this been tested?
The changes have been tested in a development environment with the following scenarios:

Normal payment flow - verified that legitimate transactions still process correctly
Manipulated ResNum parameter - verified that the system correctly reverses the transaction and returns error -101
Replayed payment response - verified that the system correctly identifies and blocks the duplicate transaction

