### PR TITLE
Update getInvoice method to use nullable type hint

### DIFF
--- a/src/Drivers/Xendit/Xendit.php
+++ b/src/Drivers/Xendit/Xendit.php
@@ -197,7 +197,7 @@ class Xendit extends Driver
     /**
      * Get invoice details
      */
-    public function getInvoice(string $invoiceId = null): array
+    public function getInvoice(?string $invoiceId = null): array
     {
         try {
             $response = $this->client->get("v2/invoices/{$invoiceId}");


### PR DESCRIPTION
Fixed Deprecated Code.

Deprecated: Shetabit\Multipay\Drivers\Xendit\Xendit::getInvoice(): Implicitly marking parameter $invoiceId as nullable is deprecated, the explicit nullable type must be used instead in \vendor\shetabit\multipay\src\Drivers\Xendit\Xendit.php on line 200

<!--- Provide a general summary of your changes in the Title above -->

## Description

Getting Deprecated code message in PHP 8.5. Hence fixed.