### PR TITLE
Fix: Correct transaction verification by comparing Token instead of ResNum

### DIFF
--- a/src/Drivers/SEP/SEP.php
+++ b/src/Drivers/SEP/SEP.php
@@ -136,7 +136,7 @@ class SEP extends Driver
             'TerminalNumber' => $this->settings->terminalId,
         ];
 
-        if ($this->invoice->getTransactionId() !== Request::input('ResNum')) {
+        if ($this->invoice->getTransactionId() !== Request::input('Token')) {
             $this->notVerified(-108);
         }
 


### PR DESCRIPTION
The SEP driver was failing verification with a "transaction not verified" error (error code `-108`). This occurred because during the `purchase` method, the `transactionId` is set to the `token` received from the gateway. However, during the `verify` process, the driver was implicitly or incorrectly comparing this `transactionId` with `ResNum` , whereas the gateway returns the `Token` in the callback for identification.

#### Solution
Updated the `verify` method to explicitly validate the `Token` returned from the gateway against the stored `transactionId`. This ensures that the verification process correctly identifies the transaction session initiated during the purchase phase.

#### Changes
- Added a check in `verify()` to compare `$this->invoice->getTransactionId()` with `Request::input('Token')`.
- Throws an `InvalidPaymentException` with code `-108` if the tokens do not match, ensuring data integrity before proceeding to the gateway's verification API.

---

### Summary of the logic change:
In your code, the fix is specifically here:
```php
if ($this->invoice->getTransactionId() !== Request::input('Token')) {
    $this->notVerified(-108);
}
```
Since you set the `transactionId` to the `token` in `purchase()`:
```php
$this->invoice->transactionId($responseData['token']);
```
This change ensures the driver validates the correct unique identifier provided by SEP.