### PR TITLE
Fix transaction ID handling in `SnappPay` gateway

### DIFF
--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -86,11 +86,17 @@ class SnappPay extends Driver
         // convert to format +98 901 XXX XXXX
         $phone = preg_replace('/^0/', '+98', $phone);
 
+        $orderId = $this->invoice->getDetail('order_id');
+        if (is_null($orderId)) {
+            $this->invoice->uuid(crc32($this->invoice->getUuid()));
+            $orderId = $this->invoice->getUuid();
+        }
+
         $data = [
             'amount' => $this->normalizerAmount($this->invoice->getAmount()),
             'mobile' => $phone,
             'paymentMethodTypeDto' => 'INSTALLMENT',
-            'transactionId' => $this->invoice->getTransactionId(),
+            'transactionId' => $orderId,
             'returnURL' => $this->settings->callbackUrl,
         ];
 

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -88,7 +88,7 @@ class SnappPay extends Driver
 
         $orderId = $this->invoice->getDetail('order_id');
         if (is_null($orderId)) {
-            $token =  substr(crc32(time()).bin2hex(random_bytes(10)), 0, 20);
+            $token =  substr(crc32((string) time()).bin2hex(random_bytes(10)), 0, 20);
 
             $this->invoice->uuid($token);
             $orderId = $token;

--- a/src/Drivers/SnappPay/SnappPay.php
+++ b/src/Drivers/SnappPay/SnappPay.php
@@ -88,8 +88,10 @@ class SnappPay extends Driver
 
         $orderId = $this->invoice->getDetail('order_id');
         if (is_null($orderId)) {
-            $this->invoice->uuid(crc32($this->invoice->getUuid()));
-            $orderId = $this->invoice->getUuid();
+            $token =  substr(crc32(time()).bin2hex(random_bytes(10)), 0, 20);
+
+            $this->invoice->uuid($token);
+            $orderId = $token;
         }
 
         $data = [


### PR DESCRIPTION
Hi,
This PR fixes the issue of passing the TransactionId into the SnappPay gateway.

**Changes made:**
- Added a check to see if the `order_id` key exists in the invoice details
- If `order_id` is not set, the UUID is converted to an integer using `crc32()` and set as the new UUID

**Why this is needed:**
Previously, the gateway was using `getTransactionId()` directly, which caused issues because the `transactionId` field is not populated until after the `purchase()` method is called.
 
**Additional context:**
This change synchronizes the SnappPay driver with the implementation used in other payment gateways, ensuring consistent behavior across the codebase.

**Fixes:** #338
