### PR TITLE
Fix: allow guzzle 7 and restore the configured callbackUrl on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## Unreleased
 
 ### Added
-- A test suite of 509 tests covering the payment manager, the invoice, the receipt, the redirection form, the event
+- A test suite of 514 tests covering the payment manager, the invoice, the receipt, the redirection form, the event
   emitter, the request helper, the abstract driver, the driver configuration and **every driver of the package**.
   The drivers are tested without touching the network: their HTTP calls are answered from a queue of prepared
   responses, and the requests they send are checked along the way.
@@ -47,13 +47,19 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - The static analysis was raised from PHPStan level 1 to level 5, and passes without a baseline.
 - `rector.php` no longer crashes: `strictBooleans` was removed from Rector 2's `withPreparedSets()`. Adding
   `declare(strict_types=1)` and rewriting `!empty($string)` are skipped on purpose, see the comments in the config.
-- **Breaking:** the dependencies were narrowed down to their latest major versions: `guzzlehttp/guzzle: ^8.0`,
-  `nesbot/carbon: ^3.13`, `chillerlan/php-cache: ^5.1` and `ramsey/uuid: ^4.9`.
+- **Breaking:** the dependencies were narrowed down to their latest major versions: `nesbot/carbon: ^3.13`,
+  `chillerlan/php-cache: ^5.1` and `ramsey/uuid: ^4.9`.
+- `guzzlehttp/guzzle` is required as `^7.8.2|^8.0`. Guzzle 8 alone would make the package uninstallable next to
+  `laravel/framework`, which requires `^7.8.2`, and with it `shetabit/payment`. The package only uses `Client`,
+  `RequestOptions` and `GuzzleException`, which behave the same in both majors, and the test suite runs against both.
 - The development dependencies were updated: PHPUnit 13, PHP_CodeSniffer 4, PHPStan 2.2 and Rector 2.6.
 - `phpunit.xml` was migrated to the current PHPUnit schema and made strict about risky tests, warnings, notices and
   deprecations.
 
 ### Removed
+- **Breaking:** the `Payment::$callbackUrl` property, which nothing ever wrote to. The `callbackUrl()` method keeps the
+  url in the settings of the driver, so the "use custom callbackUrl if exists" branch it fed in
+  `getFreshDriverInstance()` could never run and went with it.
 - The Travis CI configuration (`.travis.yml`), replaced by GitHub Actions.
 - The StyleCI configuration (`.styleci.yml`), replaced by the PHP_CodeSniffer workflow.
 - The unused and broken `Shetabit\Multipay\Tests\Traits\DriverCommon` test trait.
@@ -61,6 +67,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   coverage badge.
 
 ### Fixed
+- `Payment::resetCallbackUrl()` puts the callbackUrl of the configuration back, the way its name and its docblock
+  always promised. It used to set the callbackUrl to `null` instead, which left the driver without one, so the only way
+  back to the configured callbackUrl was to select the driver again with `via()`. A driver that has no callbackUrl in
+  the configuration no longer receives the key at all after a reset, exactly like before it was overwritten.
 - `chillerlan/php-settings-container` below 3.2 is declared as a conflict: 3.1.x declares implicitly nullable
   parameters, which PHP 8.4 deprecated, and it was what the lowest supported dependencies resolved to (3.2.0 fixed it
   upstream). Composer now refuses to install those versions. Any deprecation - ours or a dependency's - fails the build.

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
         "php": "^8.4",
         "ext-json": "*",
         "chillerlan/php-cache": "^5.1",
-        "guzzlehttp/guzzle": "^8.0",
+        "guzzlehttp/guzzle": "^7.8.2|^8.0",
         "nesbot/carbon": "^3.13",
         "ramsey/uuid": "^4.9"
     },

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -29,11 +29,6 @@ class Payment
     protected array $settings = [];
 
     /**
-     * Url the gateway sends the customer back to.
-     */
-    protected string|null $callbackUrl = null;
-
-    /**
      * Name of the current payment driver.
      */
     protected string $driver = '';
@@ -84,6 +79,9 @@ class Payment
 
     /**
      * Set callbackUrl.
+     *
+     * The url becomes a setting of the driver that is selected at the time, so
+     * a `via()` after it hands the driver its own callbackUrl again.
      */
     public function callbackUrl(string|null $url = null): static
     {
@@ -97,7 +95,13 @@ class Payment
      */
     public function resetCallbackUrl(): static
     {
-        $this->callbackUrl();
+        $settings = $this->driverConfig($this->driver);
+
+        if (array_key_exists('callbackUrl', $settings)) {
+            $this->settings['callbackUrl'] = $settings['callbackUrl'];
+        } else { // the current driver has no callbackUrl of its own
+            unset($this->settings['callbackUrl']);
+        }
 
         return $this;
     }
@@ -147,7 +151,7 @@ class Payment
         $this->driver = $driver;
         $this->validateDriver();
         $this->invoice->via($driver);
-        $this->settings = array_merge($this->loadDefaultConfig()['drivers'][$driver] ?? [], $this->config['drivers'][$driver]);
+        $this->settings = $this->driverConfig($driver);
 
         return $this;
     }
@@ -241,6 +245,20 @@ class Payment
     }
 
     /**
+     * The settings of the given driver, the way they are in the configuration.
+     *
+     * The settings that ship with the package are the ones a driver falls back
+     * to for the keys the user did not configure themselves.
+     */
+    protected function driverConfig(string $driver) : array
+    {
+        return array_merge(
+            $this->loadDefaultConfig()['drivers'][$driver] ?? [],
+            $this->config['drivers'][$driver] ?? []
+        );
+    }
+
+    /**
      * Set invoice instance.
      */
     protected function invoice(Invoice $invoice): static
@@ -269,10 +287,6 @@ class Payment
     {
         $this->validateDriver();
         $class = $this->config['map'][$this->driver];
-
-        if (!empty($this->callbackUrl)) { // use custom callbackUrl if exists
-            $this->settings['callbackUrl'] = $this->callbackUrl;
-        }
 
         return new $class($this->invoice, $this->settings);
     }

--- a/tests/PaymentTest.php
+++ b/tests/PaymentTest.php
@@ -120,6 +120,71 @@ class PaymentTest extends TestCase
         $this->assertEquals('/random_url', $manager->getCallbackUrl());
     }
 
+    public function testResetCallbackUrlRestoresTheConfiguredCallbackUrl(): void
+    {
+        $manager = $this->getManagerFreshInstance();
+
+        $configured = $manager->getCallbackUrl();
+
+        $manager->callbackUrl('/random_url');
+
+        $this->assertSame('/random_url', $manager->getCallbackUrl());
+
+        $manager->resetCallbackUrl();
+
+        $this->assertSame($configured, $manager->getCallbackUrl());
+    }
+
+    public function testResetCallbackUrlRestoresTheCallbackUrlTheUserConfigured(): void
+    {
+        // The settings of the user win over the ones that ship with the package,
+        // so a reset has to end up at the user's callbackUrl.
+        $config = $this->config();
+        $config['drivers'][$config['default']]['callbackUrl'] = '/the-users-callback';
+
+        $manager = new MockPaymentManager($config);
+
+        $manager->callbackUrl('/random_url')->resetCallbackUrl();
+
+        $this->assertSame('/the-users-callback', $manager->getCallbackUrl());
+    }
+
+    public function testResetCallbackUrlRemovesTheSettingOfADriverThatHasNoneConfigured(): void
+    {
+        $manager = $this->getManagerFreshInstance();
+
+        $manager->via('bar')->callbackUrl('/random_url');
+
+        $this->assertSame('/random_url', $manager->getCallbackUrl());
+
+        $manager->resetCallbackUrl();
+
+        // The `bar` driver is configured without a callbackUrl, so there is
+        // nothing to restore and the setting goes away completely.
+        $this->assertArrayNotHasKey('callbackUrl', $manager->getCurrentDriverSetting());
+    }
+
+    public function testResetCallbackUrlLeavesTheOtherSettingsAlone(): void
+    {
+        $manager = $this->getManagerFreshInstance();
+
+        $manager->config('foo', 'bar')->callbackUrl('/random_url')->resetCallbackUrl();
+
+        $this->assertSame('bar', $manager->getCurrentDriverSetting()['foo']);
+    }
+
+    public function testResetCallbackUrlRestoresTheCallbackUrlOfTheDriverInUse(): void
+    {
+        $manager = $this->getManagerFreshInstance();
+
+        $manager->via('local')->callbackUrl('/random_url')->resetCallbackUrl();
+
+        $this->assertSame(
+            $this->config()['drivers']['local']['callbackUrl'],
+            $manager->getCallbackUrl()
+        );
+    }
+
     public function testAmountCanBeSetted(): void
     {
         $amount = 10000;


### PR DESCRIPTION
## Guzzle

Requiring `guzzlehttp/guzzle: ^8.0` alone makes this package uninstallable next to `laravel/framework`, which requires `^7.8.2` — and with it `shetabit/payment`, since every Laravel application has the framework:

```
- laravel/framework[v12.61.1, ..., v13.25.0] require guzzlehttp/guzzle ^7.8.2
- shetabit/multipay v3.0.0 requires guzzlehttp/guzzle ^8.0
- Conclusion: don't install guzzlehttp/guzzle 7.15.3 (conflict analysis result)
```

The package only uses `GuzzleHttp\Client`, `GuzzleHttp\RequestOptions` and `GuzzleHttp\Exception\GuzzleException`, which behave the same in both majors, so the constraint is `^7.8.2|^8.0` now. The full test suite was run against both (guzzle 7.15.2 + psr7 2.13 and guzzle 8.0.2 + psr7 3.0), on PHP 8.4 and 8.5.

## `resetCallbackUrl()`

`Payment::resetCallbackUrl()` called `callbackUrl()` without an argument, which set the callbackUrl setting to `null` rather than putting the configured one back — despite the name of the method and its docblock ("Reset the callbackUrl to its original that exists in configs"). The driver was left without a callbackUrl, and the only way back to the configured one was to select the driver again with `via()`.

It now restores the callbackUrl of the driver in use, taking the user's configuration over the one that ships with the package, and removes the setting entirely for a driver that has none configured — the state the settings were in before the callbackUrl was overwritten. The merge that `via()` does was extracted into `driverConfig()` so both paths read the configuration the same way.

Five tests were added to `tests/PaymentTest.php`; four of them fail on `master`.

## Dead code: `Payment::$callbackUrl`

Nothing ever wrote to the `protected string|null $callbackUrl` property, which made the branch it fed in `getFreshDriverInstance()` unreachable:

```php
if (!empty($this->callbackUrl)) { // use custom callbackUrl if exists
    $this->settings['callbackUrl'] = $this->callbackUrl;
}
```

`callbackUrl()` keeps the url in `$settings` instead, so the property and the branch are gone. Removing them cannot change behaviour — the condition was never true. It is listed as breaking in the changelog all the same, since the property was `protected` and a subclass outside the package could have set it.

The sharp edge that branch looks like it was meant to smooth over is unchanged and now documented on `callbackUrl()`: the url lands in the settings of the driver selected at that moment, so `callbackUrl('/x')->via('bar')` hands `bar` its own callbackUrl, while `via('bar')->callbackUrl('/x')` keeps `/x`. Happy to make a custom callbackUrl survive a driver switch in a follow-up if that is the behaviour you want.

## Checks

`composer ci` (PHP_CodeSniffer, PHPStan level 5, PHPUnit) passes: **514 tests, 2008 assertions**, with both guzzle majors on PHP 8.4 and 8.5.

> Note: `shetabit/payment` can only pick this up once it is tagged — `^3.0` resolves against releases, so a `v3.0.1` tag is needed after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)