### PR TITLE
fix(jibit): Support additional Jibit purchase fields

### DIFF
--- a/src/Drivers/Jibit/Jibit.php
+++ b/src/Drivers/Jibit/Jibit.php
@@ -36,20 +36,37 @@ class Jibit extends Driver
     /**
      * Purchase invoice
      *
-     * @return string
+     * @return int|string|null
      * @throws PurchaseFailedException
      */
-    public function purchase() : string|int|null
-    {
+        public function purchase(): int|null|string
+        {
         $amount = $this->invoice->getAmount() * ($this->settings->currency == 'T' ? 10 : 1); // Convert to Rial
+
+        $payerMobileNumber = $this->invoice->getDetail('payerMobileNumber')
+            ?? $this->invoice->getDetail('mobile');
+
+        $payload = [
+            'wage' => $this->invoice->getDetail('wage'),
+            'payerMobileNumber' => $payerMobileNumber,
+            'checkPayerMobileNumber' => $this->invoice->getDetail('checkPayerMobileNumber'),
+            'payerCardNumber' => $this->invoice->getDetail('payerCardNumber'),
+            'payerCardNumbers' => $this->invoice->getDetail('payerCardNumbers'),
+            'payerNationalCode' => $this->invoice->getDetail('payerNationalCode'),
+            'description' => $this->invoice->getDetail('description'),
+            'switching' => $this->invoice->getDetail('switching'),
+            'additionalData' => $this->invoice->getDetail('additionalData'),
+            'userIdentifier' => $this->invoice->getDetail('userIdentifier'),
+        ];
 
         $requestResult = $this->jibit->paymentRequest(
             $amount,
             $this->invoice->getUuid(),
-            $this->invoice->getDetail('mobile'),
-            $this->settings->callbackUrl
+            $payerMobileNumber,
+            $this->settings->callbackUrl,
+            $this->settings->currency ?? 'IRR',
+            $payload
         );
-
 
         if (! empty($requestResult['pspSwitchingUrl'])) {
             $this->paymentUrl = $requestResult['pspSwitchingUrl'];
@@ -57,8 +74,7 @@ class Jibit extends Driver
 
         if (! empty($requestResult['errors'])) {
             $errMsgs = array_map(fn (array $err) => $err['code'], $requestResult['errors']);
-
-            throw new PurchaseFailedException(implode('\n', $errMsgs));
+            throw new PurchaseFailedException(implode("\n", $errMsgs));
         }
 
         $purchaseId = $requestResult['purchaseId'];

--- a/src/Drivers/Jibit/JibitClient.php
+++ b/src/Drivers/Jibit/JibitClient.php
@@ -53,21 +53,40 @@ class JibitClient
      * @param int $amount
      * @param string $referenceNumber
      * @param string $userIdentifier
+     * @param $callbackUrl
+     * @param string $currency
+     * @param array $payload
+     * @return bool|mixed|string
      * @throws PurchaseFailedException
      */
-    public function paymentRequest(int|float $amount, string|int $referenceNumber, string|null $userIdentifier, string $callbackUrl, string $currency = 'IRR', string|null $description = null, mixed $additionalData = null) : mixed
+    public function paymentRequest(
+        int    $amount,
+        string $referenceNumber,
+        string $userIdentifier,
+        $callbackUrl,
+        string $currency = 'IRR',
+        array $payload = []
+    ): mixed
     {
         $this->generateToken();
 
         $data = [
-            'additionalData' => $additionalData,
             'amount' => $amount,
-            'callbackUrl' => $callbackUrl,
-            'clientReferenceNumber' => $referenceNumber,
             'currency' => $currency,
+            'clientReferenceNumber' => (string) $referenceNumber,
+            'callbackUrl' => $callbackUrl,
             'userIdentifier' => $userIdentifier,
-            'description' => $description,
         ];
+
+        if (is_array($payload)) {
+            $payload = array_filter($payload, static fn ($value) => $value !== null);
+
+            if (isset($payload['additionalData']) && is_array($payload['additionalData'])) {
+                $payload['additionalData'] = json_encode($payload['additionalData'], JSON_UNESCAPED_UNICODE);
+            }
+
+            $data = array_merge($data, $payload);
+        }
 
         return $this->callCurl('/purchases', $data, true);
     }


### PR DESCRIPTION
Adds support for forwarding Jibit-specific invoice details to the `POST /purchases` request.

Supported fields include payer mobile verification, payer card restrictions, payer national code, wage, switching, additional data, description, and user identifier.

The legacy `mobile` detail remains supported as a fallback for `payerMobileNumber`.