### PR TITLE
[feat] add DoubleQuoteUsage to PhpCsFixer Rule

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -279,9 +279,9 @@ return [
             'PaymentIdentity' => '',
             'MultiIdentityRows' => [
                 [
-                    "IbanNumber" => '', // Sheba number (with IR)
-                    "Amount" => 0,
-                    "PaymentIdentity" => '',
+                    'IbanNumber' => '', // Sheba number (with IR)
+                    'Amount' => 0,
+                    'PaymentIdentity' => '',
                 ],
             ],
             'description' => 'payment using sadad',

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,8 @@
 
     <rule ref="PSR2"/>
 
+    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+
     <!--
         The constants of the drivers below are part of the public API of the package.
         Renaming them would break every application that references them, so they are

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,9 @@
 
     <rule ref="PSR2"/>
 
-    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
+    </rule>
 
     <!--
         The constants of the drivers below are part of the public API of the package.

--- a/src/Drivers/Aqayepardakht/Aqayepardakht.php
+++ b/src/Drivers/Aqayepardakht/Aqayepardakht.php
@@ -40,7 +40,7 @@ class Aqayepardakht extends Driver
     public function purchase(): string|int|null
     {
         $data = [
-            'pin' => $this->settings->mode === "normal" ? $this->settings->pin : "sandbox",
+            'pin' => $this->settings->mode === 'normal' ? $this->settings->pin : 'sandbox',
             'amount' => $this->convertAmountToToman($this->invoice->getAmount()),
             'callback' => $this->settings->callbackUrl,
             'invoice_id' => $this->settings->invoice_id,
@@ -55,7 +55,7 @@ class Aqayepardakht extends Driver
                 [
                     'json' => $data,
                     'headers' => [
-                        "Accept" => "application/json",
+                        'Accept' => 'application/json',
                     ],
                     'http_errors' => false,
                 ]
@@ -74,7 +74,7 @@ class Aqayepardakht extends Driver
 
     public function pay(): RedirectionForm
     {
-        $url = $this->settings->mode === "normal" ? $this->settings->apiPaymentUrl : $this->settings->apiPaymentUrlSandbox;
+        $url = $this->settings->mode === 'normal' ? $this->settings->apiPaymentUrl : $this->settings->apiPaymentUrlSandbox;
         $url .= $this->invoice->getTransactionId();
 
         return $this->redirectWithForm($url, [], 'GET');
@@ -87,9 +87,9 @@ class Aqayepardakht extends Driver
      */
     public function verify(): ReceiptInterface
     {
-        $tracking_number = Request::post("tracking_number");
-        $transid = Request::post("transid");
-        if ($tracking_number === null || $tracking_number === ""|| $transid === ""|| $transid === null) {
+        $tracking_number = Request::post('tracking_number');
+        $transid = Request::post('transid');
+        if ($tracking_number === null || $tracking_number === ''|| $transid === ''|| $transid === null) {
             $this->notVerified('پرداخت ناموفق.');
         }
         $data = [
@@ -104,7 +104,7 @@ class Aqayepardakht extends Driver
                 [
                     'json' => $data,
                     'headers' => [
-                        "Accept" => "application/json",
+                        'Accept' => 'application/json',
                     ],
                     'http_errors' => false,
                 ]
@@ -114,10 +114,10 @@ class Aqayepardakht extends Driver
 
         if ($responseBody['status'] !== self::PAYMENT_STATUS_OK) {
             if (isset($responseBody['code'])) {
-                $message = $this->getErrorMessage($responseBody["code"]);
+                $message = $this->getErrorMessage($responseBody['code']);
             }
 
-            $this->notVerified($message ?? '', $responseBody["code"]);
+            $this->notVerified($message ?? '', $responseBody['code']);
         }
         return $this->createReceipt($tracking_number);
     }
@@ -151,23 +151,23 @@ class Aqayepardakht extends Driver
     {
         $code = (int)$code;
         return match ($code) {
-            -1 => "مبلغ نباید خالی باشد.",
-            -2 => "کد پین درگاه نمیتواند خالی باشد.",
-            -3 => "آدرس بازگشت نمیتواند خالی باشد.",
-            -4 => "مبلغ وارد شده اشتباه است.",
-            -5 => "مبلع باید بین 100 تومان تا 50 میلیون تومان باشد.",
-            -6 => "کد پین وارد شده اشتباه است.",
-            -7 => "کد تراکنش نمیتواند خالی باشد.",
-            -8 => "تراکنش مورد نظر وجود ندارد.",
-            -9 => "کد پین درگاه با درگاه تراکنش مطابقت ندارد.",
-            -10 => "مبلغ با مبلغ تراکنش مطابقت ندارد.",
-            -11 => "درگاه در انتظار تایید و یا غیرفعال است.",
-            -12 => "امکان ارسال درخواست برای این پذیرنده وجود ندارد.",
-            -13 => "شماره کارت باید 16 رقم چسبیده بهم باشد.",
-            0 => "پرداخت انجام نشد.",
-            1 => "پرداخت با موفقیت انجام شد.",
-            2 => "تراکنش قبلا وریفای شده است.",
-            default => "خطای نامشخص.",
+            -1 => 'مبلغ نباید خالی باشد.',
+            -2 => 'کد پین درگاه نمیتواند خالی باشد.',
+            -3 => 'آدرس بازگشت نمیتواند خالی باشد.',
+            -4 => 'مبلغ وارد شده اشتباه است.',
+            -5 => 'مبلع باید بین 100 تومان تا 50 میلیون تومان باشد.',
+            -6 => 'کد پین وارد شده اشتباه است.',
+            -7 => 'کد تراکنش نمیتواند خالی باشد.',
+            -8 => 'تراکنش مورد نظر وجود ندارد.',
+            -9 => 'کد پین درگاه با درگاه تراکنش مطابقت ندارد.',
+            -10 => 'مبلغ با مبلغ تراکنش مطابقت ندارد.',
+            -11 => 'درگاه در انتظار تایید و یا غیرفعال است.',
+            -12 => 'امکان ارسال درخواست برای این پذیرنده وجود ندارد.',
+            -13 => 'شماره کارت باید 16 رقم چسبیده بهم باشد.',
+            0 => 'پرداخت انجام نشد.',
+            1 => 'پرداخت با موفقیت انجام شد.',
+            2 => 'تراکنش قبلا وریفای شده است.',
+            default => 'خطای نامشخص.',
         };
     }
 }

--- a/src/Drivers/Asanpardakht/Asanpardakht.php
+++ b/src/Drivers/Asanpardakht/Asanpardakht.php
@@ -135,13 +135,13 @@ class Asanpardakht extends Driver
         $client = new Client(['base_uri' => $this->settings->apiRestPaymentUrl]);
 
         $response = $client->request($method, $url, [
-            "json" => $data,
-            "headers" => [
+            'json' => $data,
+            'headers' => [
                 'Content-Type' => 'application/json',
                 'usr' => $this->settings->username,
                 'pwd' => $this->settings->password
             ],
-            "http_errors" => false,
+            'http_errors' => false,
         ]);
 
         return [
@@ -178,7 +178,7 @@ class Asanpardakht extends Driver
             'amountInRials' => $this->convertAmountToRial($this->invoice->getAmount()),
             'localDate' => $this->getTime()['content'],
             'callbackURL' => $this->settings->callbackUrl . $query,
-            'paymentId' => "0",
+            'paymentId' => '0',
             'additionalData' => '',
         ]);
     }
@@ -261,45 +261,45 @@ class Asanpardakht extends Driver
     protected function purchaseFailed(int|string|null $status) : never
     {
         $translations = [
-            400 => "bad request",
-            401 => "unauthorized. probably wrong or unsent header(s)",
-            471 => "identity not trusted to proceed",
-            472 => "no records found",
-            473 => "invalid merchant username or password",
-            474 => "invalid incoming request machine ip. check response body to see your actual public IP address",
-            475 => "invoice identifier is not a number",
-            476 => "request amount is not a number",
-            477 => "request local date length is invalid",
-            478 => "request local date is not in valid format",
-            479 => "invalid service type id",
-            480 => "invalid payer id",
-            481 => "incorrect settlement description format",
-            482 => "settlement slices does not match total amount",
-            483 => "unregistered iban",
-            484 => "internal error for other reasons",
-            485 => "invalid local date",
-            486 => "amount not in range",
-            487 => "service not found or not available for merchant",
-            488 => "invalid default callback",
-            489 => "duplicate local invoice id",
-            490 => "merchant disabled or misconfigured",
-            491 => "too many settlement destinations",
-            492 => "unprocessable request",
-            493 => "error processing special request for other reasons like business restrictions",
-            494 => "invalid payment_id for governmental payment",
-            495 => "invalid referenceId in additionalData",
-            496 => "invalid json in additionalData",
-            497 => "invalid payment_id location",
-            571 => "misconfiguration OR not yet processed",
-            572 => "misconfiguration OR transaction status undetermined",
-            573 => "misconfiguraed valid ips for configuration OR unable to request for verification due to an internal error",
-            574 => "internal error in uthorization",
-            575 => "no valid ibans found for merchant",
-            576 => "internal error",
-            577 => "internal error",
-            578 => "no default sharing is defined for merchant",
-            579 => "cant submit ibans with default sharing endpoint",
-            580 => "error processing special request"
+            400 => 'bad request',
+            401 => 'unauthorized. probably wrong or unsent header(s)',
+            471 => 'identity not trusted to proceed',
+            472 => 'no records found',
+            473 => 'invalid merchant username or password',
+            474 => 'invalid incoming request machine ip. check response body to see your actual public IP address',
+            475 => 'invoice identifier is not a number',
+            476 => 'request amount is not a number',
+            477 => 'request local date length is invalid',
+            478 => 'request local date is not in valid format',
+            479 => 'invalid service type id',
+            480 => 'invalid payer id',
+            481 => 'incorrect settlement description format',
+            482 => 'settlement slices does not match total amount',
+            483 => 'unregistered iban',
+            484 => 'internal error for other reasons',
+            485 => 'invalid local date',
+            486 => 'amount not in range',
+            487 => 'service not found or not available for merchant',
+            488 => 'invalid default callback',
+            489 => 'duplicate local invoice id',
+            490 => 'merchant disabled or misconfigured',
+            491 => 'too many settlement destinations',
+            492 => 'unprocessable request',
+            493 => 'error processing special request for other reasons like business restrictions',
+            494 => 'invalid payment_id for governmental payment',
+            495 => 'invalid referenceId in additionalData',
+            496 => 'invalid json in additionalData',
+            497 => 'invalid payment_id location',
+            571 => 'misconfiguration OR not yet processed',
+            572 => 'misconfiguration OR transaction status undetermined',
+            573 => 'misconfiguraed valid ips for configuration OR unable to request for verification due to an internal error',
+            574 => 'internal error in uthorization',
+            575 => 'no valid ibans found for merchant',
+            576 => 'internal error',
+            577 => 'internal error',
+            578 => 'no default sharing is defined for merchant',
+            579 => 'cant submit ibans with default sharing endpoint',
+            580 => 'error processing special request'
         ];
 
         if (array_key_exists($status, $translations)) {

--- a/src/Drivers/Atipay/Core/fn.atipay.php
+++ b/src/Drivers/Atipay/Core/fn.atipay.php
@@ -27,12 +27,12 @@ function fn_atipay_get_token($params): array
             if (isset($r['faMessage']) && !empty($r['faMessage'])) {
                 $return['errorMessage'] = $r['faMessage'];
             } else {
-                $return['errorMessage'] = "خطا در دریافت توکن پرداخت";
+                $return['errorMessage'] = 'خطا در دریافت توکن پرداخت';
             }
         }
     } else {
         $return['success']=0;
-        $return['errorMessage'] = "خطا در دریافت اطلاعات توکن پرداخت";
+        $return['errorMessage'] = 'خطا در دریافت اطلاعات توکن پرداخت';
     }
 
     return $return;
@@ -67,7 +67,7 @@ function _fn_generate_get_token_form($params, $submit_text, $action): string
 
     $form .= "<input type='submit' value='$submit_text' name='submit' >";
 
-    return $form . "</form>";
+    return $form . '</form>';
 }
 
 function fn_check_callback_data(array $params): array
@@ -77,14 +77,14 @@ function fn_check_callback_data(array $params): array
         $state = $params['state'];
         if ($state == 'OK') {
             $result['success']=1;
-            $result['error']="";
+            $result['error']='';
         } else {
             $result['success']=0;
             $result['error']= _fn_return_state_text($state);
         }
     } else {
         $result['success']=0;
-        $result['error']="خطای نامشخص در پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.";
+        $result['error']='خطای نامشخص در پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.';
     }
 
     return $result;
@@ -101,18 +101,18 @@ function fn_atipay_verify_payment($params, $amount): array
         if (isset($r['amount']) && !empty($r['amount'])) {
             if ($r['amount'] == $amount) {
                 $return['success']=1;
-                $return['errorMessage']="";
+                $return['errorMessage']='';
             } else {
                 $return['success']=0;
-                $return['errorMessage']="خطا در تایید مبلغ پرداخت.در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.";
+                $return['errorMessage']='خطا در تایید مبلغ پرداخت.در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.';
             }
         } else {
             $return['success']=0;
-            $return['errorMessage']="خطا در تایید اطلاعات پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.";
+            $return['errorMessage']='خطا در تایید اطلاعات پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.';
         }
     } else {
         $return['success']=0;
-        $return['errorMessage'] = "خطا در تایید نهایی پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.";
+        $return['errorMessage'] = 'خطا در تایید نهایی پرداخت. در صورتیکه مبلغی از شما کسر شده باشد، برگشت داده می شود.';
     }
 
     return $return;
@@ -121,15 +121,15 @@ function fn_atipay_verify_payment($params, $amount): array
 function _fn_return_state_text($state): string
 {
     return match ($state) {
-        "CanceledByUser" => "پرداخت توسط شما لغو شده است.",
-        "Failed" => "پرداخت انجام نشد.",
-        "SessionIsNull" => "کاربر در بازه زمانی تعیین شده پاسخی ارسال نکرده است",
-        "InvalidParameters" => "پارامترهاي ارسالی نامعتبر است",
-        "MerchantIpAddressIsInvalid" => "آدرس سرور پذیرنده نامعتبر است",
-        "TokenNotFound" => "توکن ارسال شده یافت نشد",
-        "TokenRequired" => "با این شماره ترمینال فقط تراکنش هاي توکنی قابل پرداخت هستند",
-        "TerminalNotFound" => "شماره ترمینال ارسال شده یافت نشد",
-        default => "خطای نامشخص در عملیات پرداخت",
+        'CanceledByUser' => 'پرداخت توسط شما لغو شده است.',
+        'Failed' => 'پرداخت انجام نشد.',
+        'SessionIsNull' => 'کاربر در بازه زمانی تعیین شده پاسخی ارسال نکرده است',
+        'InvalidParameters' => 'پارامترهاي ارسالی نامعتبر است',
+        'MerchantIpAddressIsInvalid' => 'آدرس سرور پذیرنده نامعتبر است',
+        'TokenNotFound' => 'توکن ارسال شده یافت نشد',
+        'TokenRequired' => 'با این شماره ترمینال فقط تراکنش هاي توکنی قابل پرداخت هستند',
+        'TerminalNotFound' => 'شماره ترمینال ارسال شده یافت نشد',
+        default => 'خطای نامشخص در عملیات پرداخت',
     };
 }
 
@@ -154,7 +154,7 @@ function wsRequestGet($url): bool|string
     $json = curl_exec($ch);
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-    if ($httpcode == "200") {
+    if ($httpcode == '200') {
         //nothing YET
     } else {
         $json= json_encode(['error'=>'Y']);
@@ -171,13 +171,13 @@ function wsRequestPost($url, $params)
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
     curl_setopt($ch, CURLOPT_TIMEOUT, 30); //timeout in seconds
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-Type: application/json;"]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json;']);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
     $json = curl_exec($ch);
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-    if ($httpcode == "200") {
+    if ($httpcode == '200') {
         return json_decode($json, true);
     }
 

--- a/src/Drivers/Azki/Azki.php
+++ b/src/Drivers/Azki/Azki.php
@@ -76,14 +76,14 @@ class Azki extends Driver
         );
 
         $data = [
-            "amount"        => $this->convertAmountToRial($this->invoice->getAmount()),
-            "redirect_uri"  => $callback,
-            "fallback_uri"  => $fallback,
-            "provider_id"   => $order_id,
-            "mobile_number" => $details['mobile'] ?? $details['phone'] ?? null,
-            "merchant_id"   => $merchant_id,
-            "description"   => $details['description'] ?? $this->settings->description,
-            "items"         => $details['items'],
+            'amount'        => $this->convertAmountToRial($this->invoice->getAmount()),
+            'redirect_uri'  => $callback,
+            'fallback_uri'  => $fallback,
+            'provider_id'   => $order_id,
+            'mobile_number' => $details['mobile'] ?? $details['phone'] ?? null,
+            'merchant_id'   => $merchant_id,
+            'description'   => $details['description'] ?? $this->settings->description,
+            'items'         => $details['items'],
         ];
 
         $response = $this->ApiCall($data, $signature, $url);
@@ -128,7 +128,7 @@ class Azki extends Driver
         $key  = $this->settings->key;
 
         $plain_signature = "{$sub_url}#{$time}#{$request_method}#{$key}";
-        $encrypt_method  = "AES-256-CBC";
+        $encrypt_method  = 'AES-256-CBC';
         $secret_key      = hex2bin($key);
 
         $digest = @openssl_encrypt($plain_signature, $encrypt_method, $secret_key, OPENSSL_RAW_DATA);
@@ -186,13 +186,13 @@ class Azki extends Driver
                 $request_method,
                 $url,
                 [
-                    "json"        => $data,
-                    "headers"     => [
+                    'json'        => $data,
+                    'headers'     => [
                         'Content-Type' => 'application/json',
                         'Signature'    => $signature,
                         'MerchantId'   => $this->settings->merchantId,
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -216,25 +216,25 @@ class Azki extends Driver
     protected function purchaseFailed(int|string|null $status) : never
     {
         $translations = [
-            "1"  => "Internal Server Error",
-            "2"  => "Resource Not Found",
-            "4"  => "Malformed Data",
-            "5"  => "Data Not Found",
-            "15" => "Access Denied",
-            "16" => "Transaction already reversed",
-            "17" => "Ticket Expired",
-            "18" => "Signature Invalid",
-            "19" => "Ticket unpayable",
-            "20" => "Ticket customer mismatch",
-            "21" => "Insufficient Credit",
-            "28" => "Unverifiable ticket due to status",
-            "32" => "Invalid Invoice Data",
-            "33" => "Contract is not started",
-            "34" => "Contract is expired",
-            "44" => "Validation exception",
-            "51" => "Request data is not valid",
-            "59" => "Transaction not reversible",
-            "60" => "Transaction must be in verified state",
+            '1'  => 'Internal Server Error',
+            '2'  => 'Resource Not Found',
+            '4'  => 'Malformed Data',
+            '5'  => 'Data Not Found',
+            '15' => 'Access Denied',
+            '16' => 'Transaction already reversed',
+            '17' => 'Ticket Expired',
+            '18' => 'Signature Invalid',
+            '19' => 'Ticket unpayable',
+            '20' => 'Ticket customer mismatch',
+            '21' => 'Insufficient Credit',
+            '28' => 'Unverifiable ticket due to status',
+            '32' => 'Invalid Invoice Data',
+            '33' => 'Contract is not started',
+            '34' => 'Contract is expired',
+            '44' => 'Validation exception',
+            '51' => 'Request data is not valid',
+            '59' => 'Transaction not reversible',
+            '60' => 'Transaction must be in verified state',
         ];
 
         if (array_key_exists($status, $translations)) {
@@ -254,7 +254,7 @@ class Azki extends Driver
         );
 
         $data = [
-            "ticket_id" => $this->invoice->getTransactionId(),
+            'ticket_id' => $this->invoice->getTransactionId(),
         ];
 
         return $this->ApiCall($data, $signature, $url)['status'];
@@ -271,19 +271,19 @@ class Azki extends Driver
     protected function verifyFailed(int|string|null $status) : never
     {
         $translations = [
-            "1" => "Created",
-            "2" => "Verified",
-            "3" => "Reversed",
-            "4" => "Failed",
-            "5" => "Canceled",
-            "6" => "Settled",
-            "7" => "Expired",
-            "8" => "Done",
-            "9" => "Settle Queue",
+            '1' => 'Created',
+            '2' => 'Verified',
+            '3' => 'Reversed',
+            '4' => 'Failed',
+            '5' => 'Canceled',
+            '6' => 'Settled',
+            '7' => 'Expired',
+            '8' => 'Done',
+            '9' => 'Settle Queue',
         ];
 
         if (array_key_exists($status, $translations)) {
-            throw new PurchaseFailedException("تراکنش در وضعیت " . $translations[$status] . " است.");
+            throw new PurchaseFailedException('تراکنش در وضعیت ' . $translations[$status] . ' است.');
         }
         throw new PurchaseFailedException('خطای ناشناخته ای رخ داده است.');
     }
@@ -309,7 +309,7 @@ class Azki extends Driver
         );
 
         $data = [
-            "ticket_id" => $this->invoice->getTransactionId(),
+            'ticket_id' => $this->invoice->getTransactionId(),
         ];
 
         return $this->ApiCall($data, $signature, $url);

--- a/src/Drivers/Behpardakht/Behpardakht.php
+++ b/src/Drivers/Behpardakht/Behpardakht.php
@@ -59,7 +59,7 @@ class Behpardakht extends Driver
         $data = explode(',', $response->return);
 
         // purchase was not successful
-        if ($data[0] !== "0") {
+        if ($data[0] !== '0') {
             throw new PurchaseFailedException($this->translateStatus($data[0]), (int)$data[0]);
         }
 
@@ -131,11 +131,11 @@ class Behpardakht extends Driver
         $receipt = $this->createReceipt($data['saleReferenceId']);
 
         $receipt->detail([
-            "RefId" => Request::input('RefId'),
-            "SaleOrderId" => Request::input('SaleOrderId'),
-            "CardHolderPan" => Request::input('CardHolderPan'),
-            "CardHolderInfo" => Request::input('CardHolderInfo'),
-            "SaleReferenceId" => Request::input('SaleReferenceId'),
+            'RefId' => Request::input('RefId'),
+            'SaleOrderId' => Request::input('SaleOrderId'),
+            'CardHolderPan' => Request::input('CardHolderPan'),
+            'CardHolderInfo' => Request::input('CardHolderInfo'),
+            'SaleReferenceId' => Request::input('SaleReferenceId'),
         ]);
 
         return $receipt;
@@ -199,7 +199,7 @@ class Behpardakht extends Driver
 
     private function client(string $url): SoapClient
     {
-        if (isset($_SERVER['SERVER_PROTOCOL']) && $_SERVER['SERVER_PROTOCOL'] == "HTTP/2.0") {
+        if (isset($_SERVER['SERVER_PROTOCOL']) && $_SERVER['SERVER_PROTOCOL'] == 'HTTP/2.0') {
             $context = stream_context_create(['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]]);
 
             return new SoapClient($url, ['stream_context' => $context]);

--- a/src/Drivers/Bitpay/Bitpay.php
+++ b/src/Drivers/Bitpay/Bitpay.php
@@ -96,9 +96,9 @@ class Bitpay extends Driver
         $receipt = $this->createReceipt($trans_id);
 
         $receipt->detail([
-            "amount" => $parseDecode->amount / $this->settings->currency->ratio(),
-            "cardNum" => $parseDecode->cardNum,
-            "factorId" => $parseDecode->factorId,
+            'amount' => $parseDecode->amount / $this->settings->currency->ratio(),
+            'cardNum' => $parseDecode->cardNum,
+            'factorId' => $parseDecode->factorId,
         ]);
 
         return $receipt;

--- a/src/Drivers/Daracard/Daracard.php
+++ b/src/Drivers/Daracard/Daracard.php
@@ -66,11 +66,11 @@ class Daracard extends Driver
         $client = new Client();
 
         $response = $client->request($method, $url, [
-            "json" => $data,
-            "headers" => [
+            'json' => $data,
+            'headers' => [
                 'Content-Type' => 'application/json',
             ],
-            "http_errors" => false,
+            'http_errors' => false,
         ]);
 
         return [
@@ -93,12 +93,12 @@ class Daracard extends Driver
         return $this->callApi('POST', $this->settings->apiPurchaseUrl, [
             'TerminalId'      => $this->settings->terminalId,
             'MerchantId'      => $this->settings->merchantId,
-            "description"     => $this->invoice->getDetail('description'),
-            "Amount"          => $amount,
-            "OrderId"         => $orderId,
-            "LocalDateTime"   => Carbon::now()->toDateTimeString(),
-            "SignData"        => $signData,
-            "ReturnUrl"       => $this->settings->callbackUrl,
+            'description'     => $this->invoice->getDetail('description'),
+            'Amount'          => $amount,
+            'OrderId'         => $orderId,
+            'LocalDateTime'   => Carbon::now()->toDateTimeString(),
+            'SignData'        => $signData,
+            'ReturnUrl'       => $this->settings->callbackUrl,
         ]);
     }
 
@@ -111,7 +111,7 @@ class Daracard extends Driver
     private function encryptPkcs7(string $str, string $key): string
     {
         $key = base64_decode($key);
-        $cipherText = openSSL_encrypt($str, "DES-EDE3", $key, 0);
+        $cipherText = openSSL_encrypt($str, 'DES-EDE3', $key, 0);
         return base64_encode($cipherText);
     }
 

--- a/src/Drivers/Digipay/Digipay.php
+++ b/src/Drivers/Digipay/Digipay.php
@@ -161,7 +161,7 @@ class Digipay extends Driver
             throw new InvalidPaymentException($message, (int) $response->getStatusCode());
         }
 
-        return new Receipt('digipay', $body["trackingCode"])->detail($body);
+        return new Receipt('digipay', $body['trackingCode'])->detail($body);
     }
 
     /**

--- a/src/Drivers/Etebarino/Etebarino.php
+++ b/src/Drivers/Etebarino/Etebarino.php
@@ -90,11 +90,11 @@ class Etebarino extends Driver
         $client = new Client();
 
         $response = $client->request($method, $url, [
-            "json" => $data,
-            "headers" => [
+            'json' => $data,
+            'headers' => [
                 'Content-Type' => 'application/json',
             ],
-            "http_errors" => false,
+            'http_errors' => false,
         ]);
 
         return [
@@ -124,8 +124,8 @@ class Etebarino extends Driver
             'merchantCode' => $this->settings->merchantId,
             'terminalPass' => $this->settings->password,
             'merchantRefCode' => $this->invoice->getUuid(),
-            "description" => $this->invoice->getDetail('description'),
-            "returnUrl" => $this->settings->callbackUrl,
+            'description' => $this->invoice->getDetail('description'),
+            'returnUrl' => $this->settings->callbackUrl,
             'paymentItems' => $this->getItems(),
         ]);
     }

--- a/src/Drivers/Gooyapay/Gooyapay.php
+++ b/src/Drivers/Gooyapay/Gooyapay.php
@@ -83,17 +83,17 @@ class Gooyapay extends Driver
         }
 
         $data = [
-            "MerchantID"    => $this->settings->merchantId,
-            "Amount"        => $amount,
-            "InvoiceID"     => $orderId,
-            "Description"   => $desc,
-            "FullName"      => $name,
-            "Email"         => $email,
-            "Mobile"        => $mobile,
-            "CallbackURL"   => $this->settings->callbackUrl,
+            'MerchantID'    => $this->settings->merchantId,
+            'Amount'        => $amount,
+            'InvoiceID'     => $orderId,
+            'Description'   => $desc,
+            'FullName'      => $name,
+            'Email'         => $email,
+            'Mobile'        => $mobile,
+            'CallbackURL'   => $this->settings->callbackUrl,
         ];
 
-        $response = $this->client->request('POST', $this->settings->apiPurchaseUrl, ["json" => $data, "http_errors" => false]);
+        $response = $this->client->request('POST', $this->settings->apiPurchaseUrl, ['json' => $data, 'http_errors' => false]);
 
         $body = json_decode($response->getBody()->getContents(), false);
 
@@ -144,12 +144,12 @@ class Gooyapay extends Driver
 
         //start verfication
         $data = [
-            "MerchantID"    => $this->settings->merchantId,
-            "Authority"     => $Authority,
-            "Amount"        => $amount,
+            'MerchantID'    => $this->settings->merchantId,
+            'Authority'     => $Authority,
+            'Amount'        => $amount,
         ];
 
-        $response = $this->client->request('POST', $this->settings->apiVerificationUrl, ["json" => $data, "http_errors" => false]);
+        $response = $this->client->request('POST', $this->settings->apiVerificationUrl, ['json' => $data, 'http_errors' => false]);
 
         $body = json_decode($response->getBody()->getContents(), false);
 

--- a/src/Drivers/IranDargah/IranDargah.php
+++ b/src/Drivers/IranDargah/IranDargah.php
@@ -121,10 +121,10 @@ class IranDargah extends Driver
             $this->getVerificationUrl(),
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 

--- a/src/Drivers/Irankish/Irankish.php
+++ b/src/Drivers/Irankish/Irankish.php
@@ -33,7 +33,7 @@ class Irankish extends Driver
         $data = $terminalID . $password . str_pad((string) $amount, 12, '0', STR_PAD_LEFT) . '00';
         $data = hex2bin($data);
         $AESSecretKey = openssl_random_pseudo_bytes(16);
-        $ivlen = openssl_cipher_iv_length($cipher = "AES-128-CBC");
+        $ivlen = openssl_cipher_iv_length($cipher = 'AES-128-CBC');
         $iv = openssl_random_pseudo_bytes($ivlen);
         $ciphertext_raw = openssl_encrypt($data, $cipher, $AESSecretKey, $options = OPENSSL_RAW_DATA, $iv);
         $hmac = hash('sha256', $ciphertext_raw, true);
@@ -42,8 +42,8 @@ class Irankish extends Driver
         openssl_public_encrypt($AESSecretKey . $hmac, $crypttext, $pubKey);
 
         return [
-            "data" => bin2hex($crypttext),
-            "iv" => bin2hex($iv),
+            'data' => bin2hex($crypttext),
+            'iv' => bin2hex($iv),
         ];
     }
 
@@ -75,18 +75,18 @@ class Irankish extends Driver
             'acceptorId' => $this->settings->acceptorId,
             'amount' => $amount,
             'billInfo' => null,
-            "paymentId" => null,
-            "requestId" => uniqid(),
-            "requestTimestamp" => time(),
-            "revertUri" => $this->settings->callbackUrl,
-            "terminalId" => $this->settings->terminalId,
-            "transactionType" => "Purchase",
+            'paymentId' => null,
+            'requestId' => uniqid(),
+            'requestTimestamp' => time(),
+            'revertUri' => $this->settings->callbackUrl,
+            'terminalId' => $this->settings->terminalId,
+            'transactionType' => 'Purchase',
         ];
         $data['authenticationEnvelope'] = $token;
         $dataString = json_encode($data);
 
         $ch = curl_init($this->settings->apiPurchaseUrl);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($ch, CURLOPT_POSTFIELDS, $dataString);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
@@ -99,9 +99,9 @@ class Irankish extends Driver
 
         $response = json_decode($result, true);
 
-        if (!$response || $response["responseCode"] != "00") {
+        if (!$response || $response['responseCode'] != '00') {
             // error has happened
-            $message = $response["description"] ?? 'خطا در هنگام درخواست برای پرداخت رخ داده است.';
+            $message = $response['description'] ?? 'خطا در هنگام درخواست برای پرداخت رخ داده است.';
             throw new PurchaseFailedException($message);
         }
 
@@ -136,7 +136,7 @@ class Irankish extends Driver
     public function verify() : ReceiptInterface
     {
         $status = Request::input('responseCode');
-        if (Request::input('responseCode') != "00") {
+        if (Request::input('responseCode') != '00') {
             $this->notVerified($status);
         }
 
@@ -150,7 +150,7 @@ class Irankish extends Driver
         $dataString = json_encode($data);
 
         $ch = curl_init($this->settings->apiVerificationUrl);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
         curl_setopt($ch, CURLOPT_POSTFIELDS, $dataString);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [

--- a/src/Drivers/Minipay/Minipay.php
+++ b/src/Drivers/Minipay/Minipay.php
@@ -54,11 +54,11 @@ class Minipay extends Driver
         }
 
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "amount" => $this->convertAmountToRial($this->invoice->getAmount()),
-            "callback_url" => $this->settings->callbackUrl,
-            "description" => $description,
-            "metadata" => array_merge($this->invoice->getDetails(), $metadata),
+            'merchant_id' => $this->settings->merchantId,
+            'amount' => $this->convertAmountToRial($this->invoice->getAmount()),
+            'callback_url' => $this->settings->callbackUrl,
+            'description' => $description,
+            'metadata' => array_merge($this->invoice->getDetails(), $metadata),
         ];
 
         $response = $this
@@ -67,11 +67,11 @@ class Minipay extends Driver
                 'POST',
                 $this->settings->apiPurchaseUrl,
                 [
-                    "json" => $data,
-                    "headers" => [
+                    'json' => $data,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -81,7 +81,7 @@ class Minipay extends Driver
             throw new PurchaseFailedException($message, $response->getStatusCode());
         }
 
-        $this->invoice->transactionId($result['data']["authority"]);
+        $this->invoice->transactionId($result['data']['authority']);
 
         // return the transaction's id
         return $this->invoice->getTransactionId();
@@ -108,9 +108,9 @@ class Minipay extends Driver
     {
         $authority = $this->invoice->getTransactionId() ?? Request::input('Authority');
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "authority" => $authority,
-            "amount" => $this->convertAmountToRial($this->invoice->getAmount()),
+            'merchant_id' => $this->settings->merchantId,
+            'authority' => $authority,
+            'amount' => $this->convertAmountToRial($this->invoice->getAmount()),
         ];
 
         $response = $this->client->request(
@@ -118,10 +118,10 @@ class Minipay extends Driver
             $this->settings->apiVerificationUrl,
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 

--- a/src/Drivers/Nextpay/Nextpay.php
+++ b/src/Drivers/Nextpay/Nextpay.php
@@ -82,8 +82,8 @@ class Nextpay extends Driver
                 'POST',
                 $this->settings->apiPurchaseUrl,
                 [
-                    "form_params" => $data,
-                    "http_errors" => false,
+                    'form_params' => $data,
+                    'http_errors' => false,
                 ]
             );
 
@@ -134,8 +134,8 @@ class Nextpay extends Driver
                 'POST',
                 $this->settings->apiVerificationUrl,
                 [
-                    "form_params" => $data,
-                    "http_errors" => false,
+                    'form_params' => $data,
+                    'http_errors' => false,
                 ]
             );
 

--- a/src/Drivers/Omidpay/Omidpay.php
+++ b/src/Drivers/Omidpay/Omidpay.php
@@ -57,11 +57,11 @@ class Omidpay extends Driver
         ];
 
         $response = $this->client->request(
-            "POST",
+            'POST',
             $this->settings->apiGenerateTokenUrl,
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                     'Accept' => 'application/json',
                     'User-Agent' => '',
@@ -72,7 +72,7 @@ class Omidpay extends Driver
         $responseStatus = $response->getStatusCode();
 
         if ($responseStatus !== 200) {
-            throw new PurchaseFailedException($this->translateStatus("unknown_error"));
+            throw new PurchaseFailedException($this->translateStatus('unknown_error'));
         }
 
         $jsonBody = $response->getBody()->getContents();
@@ -114,10 +114,10 @@ class Omidpay extends Driver
         $refNum = Request::input('RefNum');
 
         $response = $this->client->request(
-            "POST",
+            'POST',
             $this->settings->apiVerificationUrl,
             [
-                "json" => [
+                'json' => [
                     'WSContext' => [
                         'UserId' => $this->settings->username,
                         'Password' => $this->settings->password,
@@ -125,7 +125,7 @@ class Omidpay extends Driver
                     'Token' => $token,
                     'RefNum' => $refNum
                 ],
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                     'Accept' => 'application/json',
                     'User-Agent' => '',
@@ -155,7 +155,7 @@ class Omidpay extends Driver
 
     private function isSucceed(string $status): bool
     {
-        return $status === "erSucceed";
+        return $status === 'erSucceed';
     }
 
     /**

--- a/src/Drivers/Panapal/Panapal.php
+++ b/src/Drivers/Panapal/Panapal.php
@@ -88,17 +88,17 @@ class Panapal extends Driver
         }
 
         $data = [
-            "MerchantID"    => $this->settings->merchantId,
-            "Amount"        => $amount,
-            "InvoiceID"     => $orderId,
-            "Description"   => $desc,
-            "FullName"      => $name,
-            "Email"         => $email,
-            "Mobile"        => $mobile,
-            "CallbackURL"   => $this->settings->callbackUrl,
+            'MerchantID'    => $this->settings->merchantId,
+            'Amount'        => $amount,
+            'InvoiceID'     => $orderId,
+            'Description'   => $desc,
+            'FullName'      => $name,
+            'Email'         => $email,
+            'Mobile'        => $mobile,
+            'CallbackURL'   => $this->settings->callbackUrl,
         ];
 
-        $response = $this->client->request('POST', $this->settings->apiPurchaseUrl, ["json" => $data, "http_errors" => false]);
+        $response = $this->client->request('POST', $this->settings->apiPurchaseUrl, ['json' => $data, 'http_errors' => false]);
 
         $body = json_decode($response->getBody()->getContents(), true);
 
@@ -149,12 +149,12 @@ class Panapal extends Driver
 
         //start verfication
         $data = [
-            "MerchantID"    => $this->settings->merchantId,
-            "Authority"     => $Authority,
-            "Amount"        => $amount,
+            'MerchantID'    => $this->settings->merchantId,
+            'Authority'     => $Authority,
+            'Amount'        => $amount,
         ];
 
-        $response = $this->client->request('POST', $this->settings->apiVerificationUrl, ["json" => $data, "http_errors" => false]);
+        $response = $this->client->request('POST', $this->settings->apiVerificationUrl, ['json' => $data, 'http_errors' => false]);
 
         $body = json_decode($response->getBody()->getContents(), true);
 

--- a/src/Drivers/Parspal/Parspal.php
+++ b/src/Drivers/Parspal/Parspal.php
@@ -153,7 +153,7 @@ class Parspal extends Driver
                     'Content-Type' => 'application/json',
                 ],
                 'json' => $data,
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 

--- a/src/Drivers/Pasargad/Pasargad.php
+++ b/src/Drivers/Pasargad/Pasargad.php
@@ -428,7 +428,7 @@ class Pasargad extends Driver
         $invoiceNumber = crc32($this->invoice->getUuid()) . random_int(0, time());
 
         $iranTime = new DateTime('now', new DateTimeZone('Asia/Tehran'));
-        $invoiceDate = $iranTime->format("Y/m/d H:i:s");
+        $invoiceDate = $iranTime->format('Y/m/d H:i:s');
 
         if (!empty($this->invoice->getDetails()['date'])) {
             $invoiceDate = $this->invoice->getDetails()['date'];

--- a/src/Drivers/Payfa/Payfa.php
+++ b/src/Drivers/Payfa/Payfa.php
@@ -62,10 +62,10 @@ class Payfa extends Driver
             'POST',
             $this->settings->apiPurchaseUrl,
             [
-                "json" => $data,
-                "http_errors" => false,
-                "headers" => [
-                    "X-API-Key" => $this->settings->apiKey,
+                'json' => $data,
+                'http_errors' => false,
+                'headers' => [
+                    'X-API-Key' => $this->settings->apiKey,
                     'Content-Type' => 'application/json',
                 ]
             ]
@@ -74,7 +74,7 @@ class Payfa extends Driver
 
 
         if ($response->getStatusCode() !== 200) {
-            throw new PurchaseFailedException($body["title"]);
+            throw new PurchaseFailedException($body['title']);
         }
 
         $this->invoice->transactionId($body['paymentId']);
@@ -110,9 +110,9 @@ class Payfa extends Driver
             'POST',
             $this->settings->apiVerificationUrl . $paymentId,
             [
-                "http_errors" => false,
-                "headers" => [
-                    "X-API-Key" => $this->settings->apiKey,
+                'http_errors' => false,
+                'headers' => [
+                    'X-API-Key' => $this->settings->apiKey,
                     'Content-Type' => 'application/json',
                 ]
             ]
@@ -120,7 +120,7 @@ class Payfa extends Driver
         $body = json_decode($response->getBody()->getContents(), true);
 
         if ($response->getStatusCode() !== 200) {
-            $this->notVerified($body["message"], $response->getStatusCode());
+            $this->notVerified($body['message'], $response->getStatusCode());
         }
 
         return $this->createReceipt($body['transactionId']);

--- a/src/Drivers/Paypal/Paypal.php
+++ b/src/Drivers/Paypal/Paypal.php
@@ -49,12 +49,12 @@ class Paypal extends Driver
                 'POST',
                 $this->getPurchaseUrl(),
                 [
-                    "json" => $params,
-                    "headers" => [
+                    'json' => $params,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                         'Authorization' => "Bearer $accessToken",
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
         $result = json_decode($response->getBody()->getContents(), true);
@@ -64,7 +64,7 @@ class Paypal extends Driver
             if (isset($result['name']) && isset($result['message'])) {
                 $message = $result['name'] . ': ' . $result['message'];
             } else {
-                $message = "Unknown error";
+                $message = 'Unknown error';
             }
 
             throw new PurchaseFailedException($message);
@@ -110,11 +110,11 @@ class Paypal extends Driver
                 'POST',
                 $verificationUrl,
                 [
-                    "headers" => [
+                    'headers' => [
                         'Content-Type' => 'application/json',
                         'Authorization' => "Bearer $accessToken",
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
         $result = json_decode($response->getBody()->getContents(), true);
@@ -125,14 +125,14 @@ class Paypal extends Driver
             if (isset($result['name']) && isset($result['message'])) {
                 $message = $result['name'] . ': ' . $result['message'];
             } else {
-                $message = "Unknown error";
+                $message = 'Unknown error';
             }
 
             throw new PurchaseFailedException($message);
         }
 
         if (isset($result['status']) && $result['status'] != 'COMPLETED') {
-            throw new PurchaseFailedException("Purchase not completed");
+            throw new PurchaseFailedException('Purchase not completed');
         }
 
         // finalize verification
@@ -198,7 +198,7 @@ class Paypal extends Driver
     {
         return [
             'intent' => 'CAPTURE',
-            "purchase_units" => [
+            'purchase_units' => [
                 [
                     'amount' => [
                         'currency_code' => $this->settings->currency,
@@ -208,9 +208,9 @@ class Paypal extends Driver
             ],
             'application_context' => [
 //                "landing_page" => "LOGIN",
-                "shipping_preference" => "NO_SHIPPING",
-                "return_url" => $this->settings->callbackUrl,
-                "cancel_url" => $this->settings->callbackUrl,
+                'shipping_preference' => 'NO_SHIPPING',
+                'return_url' => $this->settings->callbackUrl,
+                'cancel_url' => $this->settings->callbackUrl,
             ],
         ];
     }
@@ -220,7 +220,7 @@ class Paypal extends Driver
      */
     protected function getAccessToken() : string
     {
-        $authorization = "Basic " . base64_encode($this->settings->clientId . ':' . $this->settings->clientSecret);
+        $authorization = 'Basic ' . base64_encode($this->settings->clientId . ':' . $this->settings->clientSecret);
 
         $response = $this
             ->client
@@ -228,14 +228,14 @@ class Paypal extends Driver
                 'POST',
                 $this->getAccessTokenUrl(),
                 [
-                    "form_params" => [
+                    'form_params' => [
                         'grant_type' => 'client_credentials',
                     ],
-                    "headers" => [
+                    'headers' => [
                         'Authorization' => $authorization,
                         'Content-Type' => 'application/x-www-form-urlencoded'
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 

--- a/src/Drivers/Payping/Payping.php
+++ b/src/Drivers/Payping/Payping.php
@@ -79,12 +79,12 @@ class Payping extends Driver
         $description = $this->extractDetails('description');
 
         $data = [
-            "amount" => $this->convertAmountToToman($this->invoice->getAmount()),
-            "returnUrl" => $this->settings->callbackUrl,
-            "payerIdentity" => $mobile ?: $email,
-            "payerName" => $name,
-            "description" => $description,
-            "clientRefId" => $this->invoice->getUuid(),
+            'amount' => $this->convertAmountToToman($this->invoice->getAmount()),
+            'returnUrl' => $this->settings->callbackUrl,
+            'payerIdentity' => $mobile ?: $email,
+            'payerName' => $name,
+            'description' => $description,
+            'clientRefId' => $this->invoice->getUuid(),
         ];
 
         $response = $this
@@ -93,12 +93,12 @@ class Payping extends Driver
                 'POST',
                 $this->settings->apiPurchaseUrl,
                 [
-                    "json" => $data,
-                    "headers" => [
-                        "Accept" => "application/json",
-                        "Authorization" => "bearer ".$this->settings->merchantId,
+                    'json' => $data,
+                    'headers' => [
+                        'Accept' => 'application/json',
+                        'Authorization' => 'bearer '.$this->settings->merchantId,
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -156,11 +156,11 @@ class Payping extends Driver
             $this->settings->apiVerificationUrl,
             [
                 'json' => $data,
-                "headers" => [
-                    "Accept" => "application/json",
-                    "Authorization" => "bearer ".$this->settings->merchantId,
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => 'bearer '.$this->settings->merchantId,
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 
@@ -177,7 +177,7 @@ class Payping extends Driver
         $receipt = $this->createReceipt($refId);
 
         $receipt->detail([
-            "cardNumber" => $this->extractResponseValue($body, 'cardNumber'),
+            'cardNumber' => $this->extractResponseValue($body, 'cardNumber'),
         ]);
 
 

--- a/src/Drivers/Pna/Pna.php
+++ b/src/Drivers/Pna/Pna.php
@@ -51,11 +51,11 @@ class Pna extends Driver
             $description = $this->settings->description;
         }
         $data = [
-            "CorporationPin" => $this->settings->CorporationPin,
-            "Amount" => $amount,
-            "OrderId" => intval(1, time()) . crc32($this->invoice->getUuid()),
-            "CallBackUrl" => $this->settings->callbackUrl,
-            "AdditionalData" => $description,
+            'CorporationPin' => $this->settings->CorporationPin,
+            'Amount' => $amount,
+            'OrderId' => intval(1, time()) . crc32($this->invoice->getUuid()),
+            'CallBackUrl' => $this->settings->callbackUrl,
+            'AdditionalData' => $description,
         ];
         if (!empty($this->invoice->getDetails()['mobile'])) {
             $data['Originator'] = $this->invoice->getDetails()['mobile'];
@@ -76,7 +76,7 @@ class Pna extends Driver
             throw new PurchaseFailedException($result['title'] ?? 'اطلاعات وارد شده اشتباه می باشد.', $result['status'] ?? 400);
         }
         if (!isset($result['status']) || (string)$result['status'] !== '0') {
-            throw new PurchaseFailedException($result['message'] ?? "خطای ناشناخته رخ داده است. در صورت کسر مبلغ از حساب حداکثر پس از 72 ساعت به حسابتان برمیگردد", $result['status'] ?? 400);
+            throw new PurchaseFailedException($result['message'] ?? 'خطای ناشناخته رخ داده است. در صورت کسر مبلغ از حساب حداکثر پس از 72 ساعت به حسابتان برمیگردد', $result['status'] ?? 400);
         }
         $this->invoice->transactionId($result['token']);
 
@@ -105,15 +105,15 @@ class Pna extends Driver
     {
         $transactionId = $this->invoice->getTransactionId() ?? Request::input('Token') ?? Request::input('token');
         $data = [
-            "CorporationPin" => $this->settings->CorporationPin,
-            "Token" => $transactionId
+            'CorporationPin' => $this->settings->CorporationPin,
+            'Token' => $transactionId
         ];
         $response = $this->client->request(
             'POST',
             $this->settings->apiConfirmationUrl,
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
                 'http_errors' => false,
@@ -124,7 +124,7 @@ class Pna extends Driver
             || ((string)$result['status'] !== '0'
                 && (string)$result['status'] !== '2')
             || (string)$result['rrn'] === '0') {
-            throw new InvalidPaymentException("خطای ناشناخته رخ داده است. در صورت کسر مبلغ از حساب حداکثر پس از 72 ساعت به حسابتان برمیگردد", $result['status'] ?? 400);
+            throw new InvalidPaymentException('خطای ناشناخته رخ داده است. در صورت کسر مبلغ از حساب حداکثر پس از 72 ساعت به حسابتان برمیگردد', $result['status'] ?? 400);
         }
         $refId = $result['rrn'];
         $receipt = new Receipt('pna', $refId);

--- a/src/Drivers/Poolam/Poolam.php
+++ b/src/Drivers/Poolam/Poolam.php
@@ -56,8 +56,8 @@ class Poolam extends Driver
             'POST',
             $this->settings->apiPurchaseUrl,
             [
-                "form_params" => $data,
-                "http_errors" => false,
+                'form_params' => $data,
+                'http_errors' => false,
             ]
         );
         $body = json_decode($response->getBody()->getContents(), true);
@@ -102,7 +102,7 @@ class Poolam extends Driver
         $response = $this->client->request(
             'POST',
             $url,
-            ["form_params" => $data, "http_errors" => false]
+            ['form_params' => $data, 'http_errors' => false]
         );
         $body = json_decode($response->getBody()->getContents(), true);
 

--- a/src/Drivers/Rayanpay/Rayanpay.php
+++ b/src/Drivers/Rayanpay/Rayanpay.php
@@ -96,7 +96,7 @@ class Rayanpay extends Driver
 
         $referenceId = hexdec(uniqid());
 
-        $callback = $this->settings->callbackUrl . "?referenceId=" . $referenceId . "&price=" . $amount . "&mobile=" . $mobile;
+        $callback = $this->settings->callbackUrl . '?referenceId=' . $referenceId . '&price=' . $amount . '&mobile=' . $mobile;
 
         $data = [
             'referenceId' => $referenceId,
@@ -200,7 +200,7 @@ class Rayanpay extends Driver
      */
     private function notVerified(int|string|null $status, string $method): void
     {
-        $message = "";
+        $message = '';
         if ($method === 'token') {
             switch ($status) {
                 case '400':

--- a/src/Drivers/Sadad/Sadad.php
+++ b/src/Drivers/Sadad/Sadad.php
@@ -63,12 +63,12 @@ class Sadad extends Driver
         }
 
         //set MobileNo for get user cards
-        $mobile = empty($this->invoice->getDetails()['mobile']) ? "" : $this->invoice->getDetails()['mobile'];
+        $mobile = empty($this->invoice->getDetails()['mobile']) ? '' : $this->invoice->getDetails()['mobile'];
 
         $data = [
             'MerchantId' => $this->settings->merchantId,
             'ReturnUrl' => $this->settings->callbackUrl,
-            'LocalDateTime' => $iranTime->format("m/d/Y g:i:s a"),
+            'LocalDateTime' => $iranTime->format('m/d/Y g:i:s a'),
             'SignData' => $signData,
             'TerminalId' => $terminalId,
             'Amount' => $amount,
@@ -109,12 +109,12 @@ class Sadad extends Driver
                 'POST',
                 $this->getPaymentUrl(),
                 [
-                    "json" => $data,
-                    "headers" => [
+                    'json' => $data,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                         'User-Agent' => '',
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -172,12 +172,12 @@ class Sadad extends Driver
                 'POST',
                 $this->settings->apiVerificationUrl,
                 [
-                    "json" => $data,
-                    "headers" => [
+                    'json' => $data,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                         'User-Agent' => '',
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -224,7 +224,7 @@ class Sadad extends Driver
     protected function encrypt_pkcs7(string $str, string $key): string
     {
         $key = base64_decode($key);
-        $ciphertext = OpenSSL_encrypt($str, "DES-EDE3", $key, OPENSSL_RAW_DATA);
+        $ciphertext = OpenSSL_encrypt($str, 'DES-EDE3', $key, OPENSSL_RAW_DATA);
 
         return base64_encode($ciphertext);
     }

--- a/src/Drivers/Saman/Saman.php
+++ b/src/Drivers/Saman/Saman.php
@@ -131,13 +131,13 @@ class Saman extends Driver
 
         $verifiedAmount = $status; // if status is bigger than 0 , it represents amount
         if ($verifiedAmount !== $this->convertAmountToRial($this->invoice->getAmount())) {
-            $soap->ReverseTransaction($data["RefNum"], $data["merchantId"], $data["password"], $verifiedAmount);
+            $soap->ReverseTransaction($data['RefNum'], $data['merchantId'], $data['password'], $verifiedAmount);
             $status = -100;
             $this->notVerified($status);
         }
 
         if ($this->getInvoice()->getTransactionId() !== Request::input('ResNum')) {
-            $soap->ReverseTransaction($data["RefNum"], $data["merchantId"], $data["password"], $verifiedAmount);
+            $soap->ReverseTransaction($data['RefNum'], $data['merchantId'], $data['password'], $verifiedAmount);
             $status = -101;
             $this->notVerified($status);
         }

--- a/src/Drivers/Sepehr/Sepehr.php
+++ b/src/Drivers/Sepehr/Sepehr.php
@@ -45,7 +45,7 @@ class Sepehr extends Driver
             $mobile = '&CellNumber=' . $this->invoice->getDetails()['mobile'];
         }
 
-        $data_query = 'Amount=' . $amount . '&callbackURL=' . $this->test_input($this->settings->callbackUrl) . '&InvoiceID=' . $this->test_input($this->invoice->getUuid()) . '&TerminalID=' . $this->test_input($this->settings->terminalId) . '&Payload=' . $this->test_input("") . $mobile;
+        $data_query = 'Amount=' . $amount . '&callbackURL=' . $this->test_input($this->settings->callbackUrl) . '&InvoiceID=' . $this->test_input($this->invoice->getUuid()) . '&TerminalID=' . $this->test_input($this->settings->terminalId) . '&Payload=' . $this->test_input('') . $mobile;
         $address_service_token = $this->settings->apiGetToken;
 
         $token_array = $this->makeHttpChargeRequest('POST', $data_query, $address_service_token);
@@ -102,7 +102,7 @@ class Sepehr extends Driver
         $status = $decode_advice_array->Status;
         $return_id = $decode_advice_array->ReturnId;
 
-        if ($status == "Ok") {
+        if ($status == 'Ok') {
             if ($return_id != $amount) {
                 throw new InvalidPaymentException('مبلغ واریز با قیمت محصول برابر نیست');
             }

--- a/src/Drivers/Sepordeh/Sepordeh.php
+++ b/src/Drivers/Sepordeh/Sepordeh.php
@@ -50,12 +50,12 @@ class Sepordeh extends Driver
         $description = $this->extractDetails('description') ?: $this->settings->description;
 
         $data = [
-            "merchant" => $this->settings->merchantId,
-            "amount" => $this->convertAmountToToman($this->invoice->getAmount()),
-            "phone" => $phone,
-            "orderId" => $orderId,
-            "callback" => $this->settings->callbackUrl,
-            "description" => $description,
+            'merchant' => $this->settings->merchantId,
+            'amount' => $this->convertAmountToToman($this->invoice->getAmount()),
+            'phone' => $phone,
+            'orderId' => $orderId,
+            'callback' => $this->settings->callbackUrl,
+            'description' => $description,
         ];
 
         $response = $this
@@ -64,8 +64,8 @@ class Sepordeh extends Driver
                 'POST',
                 $this->settings->apiPurchaseUrl,
                 [
-                    "form_params" => $data,
-                    "http_errors" => false,
+                    'form_params' => $data,
+                    'http_errors' => false,
                     'verify' => false,
                 ]
             );
@@ -149,7 +149,7 @@ class Sepordeh extends Driver
             $this->settings->apiVerificationUrl,
             [
                 'form_params' => $data,
-                "http_errors" => false,
+                'http_errors' => false,
                 'verify' => false,
             ]
         );

--- a/src/Drivers/Shepa/Shepa.php
+++ b/src/Drivers/Shepa/Shepa.php
@@ -123,10 +123,10 @@ class Shepa extends Driver
             $this->getVerificationUrl(),
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 

--- a/src/Drivers/Stripe/Stripe.php
+++ b/src/Drivers/Stripe/Stripe.php
@@ -39,8 +39,8 @@ class Stripe extends Driver
                 'line_items[0][price_data][product_data][name]' => 'Order #' . uniqid(),
                 'line_items[0][quantity]' => 1,
                 'mode' => 'payment',
-                'success_url' => $this->settings->success_url . "?session_id={CHECKOUT_SESSION_ID}",
-                'cancel_url' => $this->settings->cancel_url . "?session_id={CHECKOUT_SESSION_ID}",
+                'success_url' => $this->settings->success_url . '?session_id={CHECKOUT_SESSION_ID}',
+                'cancel_url' => $this->settings->cancel_url . '?session_id={CHECKOUT_SESSION_ID}',
             ],
         ]);
 

--- a/src/Drivers/Toman/Toman.php
+++ b/src/Drivers/Toman/Toman.php
@@ -40,7 +40,7 @@ class Toman extends Driver
     // Purchase the invoice, save its transactionId and finaly return it.
     public function purchase(): string|int|null
     {
-        $url = $this->base_url . "/users/me/shops/" . $this->shop_slug . "/deals";
+        $url = $this->base_url . '/users/me/shops/' . $this->shop_slug . '/deals';
         $data = $this->settings->data;
 
         $response = $this->client
@@ -51,7 +51,7 @@ class Toman extends Driver
                     'json' => $data,
                     'headers' => [
                         'Authorization' => "Basic {$this->auth_token}",
-                        "Content-Type" => 'application/json'
+                        'Content-Type' => 'application/json'
                     ]
                 ]
             );
@@ -80,7 +80,7 @@ class Toman extends Driver
         $state = Request::input('state');
 
         $transactionId = $this->invoice->getTransactionId();
-        $verifyUrl = $this->base_url . "/users/me/shops/" . $this->shop_slug . "/deals/" . $transactionId . "/verify";
+        $verifyUrl = $this->base_url . '/users/me/shops/' . $this->shop_slug . '/deals/' . $transactionId . '/verify';
 
         if ($state != 'funded') {
             throw new InvalidPaymentException('پرداخت انجام نشد');
@@ -93,7 +93,7 @@ class Toman extends Driver
                 [
                     'headers' => [
                         'Authorization' => "Basic {$this->auth_token}",
-                        "Content-Type" => 'application/json'
+                        'Content-Type' => 'application/json'
                     ]
                 ]
             );

--- a/src/Drivers/Vandar/Vandar.php
+++ b/src/Drivers/Vandar/Vandar.php
@@ -72,7 +72,7 @@ class Vandar extends Driver
                 [
                     'json' => $data,
                     'headers' => [
-                        "Accept" => "application/json",
+                        'Accept' => 'application/json',
                     ],
                     'http_errors' => false,
                 ]
@@ -124,7 +124,7 @@ class Vandar extends Driver
                 [
                     'json' => $data,
                     'headers' => [
-                        "Accept" => "application/json",
+                        'Accept' => 'application/json',
                     ],
                     'http_errors' => false,
                 ]
@@ -148,10 +148,10 @@ class Vandar extends Driver
         $receipt = $this->createReceipt($token);
 
         $receipt->detail([
-            "amount" => $responseBody['amount'],
-            "realAmount" => $responseBody['realAmount'],
-            "wage" => $responseBody['wage'],
-            "cardNumber" => $responseBody['cardNumber'],
+            'amount' => $responseBody['amount'],
+            'realAmount' => $responseBody['realAmount'],
+            'wage' => $responseBody['wage'],
+            'cardNumber' => $responseBody['cardNumber'],
         ]);
 
         return $receipt;

--- a/src/Drivers/Zarinpal/Strategies/Normal.php
+++ b/src/Drivers/Zarinpal/Strategies/Normal.php
@@ -54,12 +54,12 @@ class Normal extends Driver
         }
 
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "amount" => $amount,
-            "currency" => 'IRR',
-            "callback_url" => $this->settings->callbackUrl,
-            "description" => $description,
-            "metadata" => $this->metadata(),
+            'merchant_id' => $this->settings->merchantId,
+            'amount' => $amount,
+            'currency' => 'IRR',
+            'callback_url' => $this->settings->callbackUrl,
+            'description' => $description,
+            'metadata' => $this->metadata(),
         ];
         if (isset($this->settings->wages)) {
             $data['wages'] = $this->settings->wages;
@@ -71,11 +71,11 @@ class Normal extends Driver
                 'POST',
                 $this->settings->apiPurchaseUrl,
                 [
-                    "json" => $data,
-                    "headers" => [
+                    'json' => $data,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
@@ -86,7 +86,7 @@ class Normal extends Driver
             throw new PurchaseFailedException($this->translateStatus($bodyResponse), $bodyResponse);
         }
 
-        $this->invoice->transactionId($result['data']["authority"]);
+        $this->invoice->transactionId($result['data']['authority']);
 
         // return the transaction's id
         return $this->invoice->getTransactionId();
@@ -114,9 +114,9 @@ class Normal extends Driver
     {
         $authority = $this->invoice->getTransactionId() ?? Request::input('Authority');
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "authority" => $authority,
-            "amount" => $this->convertAmountToRial($this->invoice->getAmount()),
+            'merchant_id' => $this->settings->merchantId,
+            'authority' => $authority,
+            'amount' => $this->convertAmountToRial($this->invoice->getAmount()),
         ];
 
         $response = $this->client->request(
@@ -124,17 +124,17 @@ class Normal extends Driver
             $this->getVerificationUrl(),
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 
         $result = json_decode($response->getBody()->getContents(), true);
 
         if (empty($result['data']) || !isset($result['data']['ref_id']) || ($result['data']['code'] != 100 && $result['data']['code'] != 101)) {
-            $bodyResponse = ($result['errors']['code'] ?? $result['data']['code']) ?? "";
+            $bodyResponse = ($result['errors']['code'] ?? $result['data']['code']) ?? '';
             throw new InvalidPaymentException($this->translateStatus($bodyResponse), $bodyResponse ?: null);
         }
 

--- a/src/Drivers/Zarinpal/Strategies/Sandbox.php
+++ b/src/Drivers/Zarinpal/Strategies/Sandbox.php
@@ -50,11 +50,11 @@ class Sandbox extends Driver
         }
 
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "amount" => $amount,
-            "currency" => 'IRR',
-            "callback_url" => $this->settings->callbackUrl,
-            "description" => $description,
+            'merchant_id' => $this->settings->merchantId,
+            'amount' => $amount,
+            'currency' => 'IRR',
+            'callback_url' => $this->settings->callbackUrl,
+            'description' => $description,
             'AdditionalData' => $this->invoice->getDetails()
         ];
 
@@ -64,22 +64,22 @@ class Sandbox extends Driver
                 'POST',
                 $this->getPurchaseUrl(),
                 [
-                    "json" => $data,
-                    "headers" => [
+                    'json' => $data,
+                    'headers' => [
                         'Content-Type' => 'application/json',
                     ],
-                    "http_errors" => false,
+                    'http_errors' => false,
                 ]
             );
 
         $result = json_decode($response->getBody()->getContents(), true);
 
         if (!empty($result['errors']) || empty($result['data']) || $result['data']['code'] != 100) {
-            $bodyResponse = ($result['errors']['code'] ?? $result['data']['code']) ?? "";
+            $bodyResponse = ($result['errors']['code'] ?? $result['data']['code']) ?? '';
             throw new InvalidPaymentException($this->translateStatus($bodyResponse), $bodyResponse ?: null);
         }
 
-        $this->invoice->transactionId($result['data']["authority"]);
+        $this->invoice->transactionId($result['data']['authority']);
 
         // return the transaction's id
         return $this->invoice->getTransactionId();
@@ -108,9 +108,9 @@ class Sandbox extends Driver
     {
         $authority = $this->invoice->getTransactionId() ?? Request::input('Authority');
         $data = [
-            "merchant_id" => $this->settings->merchantId,
-            "authority" => $authority,
-            "amount" => $this->convertAmountToRial($this->invoice->getAmount()),
+            'merchant_id' => $this->settings->merchantId,
+            'authority' => $authority,
+            'amount' => $this->convertAmountToRial($this->invoice->getAmount()),
         ];
 
         $response = $this->client->request(
@@ -118,10 +118,10 @@ class Sandbox extends Driver
             $this->getVerificationUrl(),
             [
                 'json' => $data,
-                "headers" => [
+                'headers' => [
                     'Content-Type' => 'application/json',
                 ],
-                "http_errors" => false,
+                'http_errors' => false,
             ]
         );
 

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -313,7 +313,7 @@ class Payment
         $reflect = new ReflectionClass($this->config['map'][$this->driver]);
 
         if (!$reflect->implementsInterface(DriverInterface::class)) {
-            throw new Exception("Driver must be an instance of Contracts\DriverInterface.");
+            throw new Exception('Driver must be an instance of Contracts\DriverInterface.');
         }
     }
 }

--- a/src/RedirectionForm.php
+++ b/src/RedirectionForm.php
@@ -124,10 +124,10 @@ class RedirectionForm implements JsonSerializable, Stringable
     public function render() : string
     {
         $data = [
-            "view" => static::getViewPath(),
-            "action" => $this->getAction(),
-            "inputs" => $this->getInputs(),
-            "method" => $this->getMethod(),
+            'view' => static::getViewPath(),
+            'action' => $this->getAction(),
+            'inputs' => $this->getInputs(),
+            'method' => $this->getMethod(),
         ];
 
         $renderer = static::$viewRenderer ?? $this->getDefaultViewRenderer();


### PR DESCRIPTION
Hi,

This PR adds the `Squiz.Strings.DoubleQuoteUsage` rule to PHP_CodeSniffer to enforce single quotes when double quotes are not necessary.


```diff
--- Original
+++ New
 <?php

-$a = "sample";
+$a = 'sample';
 $b = "sample with 'single-quotes'";
```