### PR TITLE
Add Referer header to Zibal requests

### DIFF
--- a/config/payment.php
+++ b/config/payment.php
@@ -357,7 +357,7 @@ return [
             'merchantId' => '',
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using zibal',
-            'referer' => 'http://yoursite.com',
+            'referer' => null,
             'currency' => IranCurrency::TOMAN,
         ],
         'sepordeh' => [

--- a/config/payment.php
+++ b/config/payment.php
@@ -357,6 +357,7 @@ return [
             'merchantId' => '',
             'callbackUrl' => 'http://yoursite.com/path/to',
             'description' => 'payment using zibal',
+            'referer' => 'http://yoursite.com',
             'currency' => IranCurrency::TOMAN,
         ],
         'sepordeh' => [

--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -87,6 +87,7 @@ class Zibal extends Driver
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
                         'Content-Type' => 'application/json',
+                        'Referer' => config('app.url'),
                     ],
                     RequestOptions::HTTP_ERRORS => false,
                 ]
@@ -153,6 +154,7 @@ class Zibal extends Driver
                 RequestOptions::HEADERS => [
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
+                    'Referer' => config('app.url'),
                 ],
                 RequestOptions::HTTP_ERRORS => false,
             ]

--- a/src/Drivers/Zibal/Zibal.php
+++ b/src/Drivers/Zibal/Zibal.php
@@ -87,7 +87,9 @@ class Zibal extends Driver
                     RequestOptions::BODY => json_encode($data),
                     RequestOptions::HEADERS => [
                         'Content-Type' => 'application/json',
-                        'Referer' => config('app.url'),
+                        ...(($this->settings->referer ?? null) === null ? [] : [
+                            'Referer' => $this->settings->referer,
+                        ]),
                     ],
                     RequestOptions::HTTP_ERRORS => false,
                 ]
@@ -154,7 +156,9 @@ class Zibal extends Driver
                 RequestOptions::HEADERS => [
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
-                    'Referer' => config('app.url'),
+                    ...(($this->settings->referer ?? null) === null ? [] : [
+                        'Referer' => $this->settings->referer,
+                    ]),
                 ],
                 RequestOptions::HTTP_ERRORS => false,
             ]

--- a/tests/Drivers/ZibalTest.php
+++ b/tests/Drivers/ZibalTest.php
@@ -85,6 +85,26 @@ class ZibalTest extends DriverTestCase
         $this->assertSame('0010000000', $this->requestJson()['nationalCode']);
     }
 
+    public function testPurchaseSendsTheConfiguredReferer(): void
+    {
+        $driver = $this->driver(['referer' => 'https://example.com']);
+        $this->fakeHttp($driver, [$this->jsonResponse(['result' => 100, 'trackId' => 1])]);
+
+        $driver->amount(1000)->purchase();
+
+        $this->assertSame('https://example.com', $this->request()->getHeaderLine('Referer'));
+    }
+
+    public function testPurchaseOmitsTheRefererByDefault(): void
+    {
+        $driver = $this->driver();
+        $this->fakeHttp($driver, [$this->jsonResponse(['result' => 100, 'trackId' => 1])]);
+
+        $driver->amount(1000)->purchase();
+
+        $this->assertFalse($this->request()->hasHeader('Referer'));
+    }
+
     public function testPurchaseFailsWhenTheGatewayReportsAnError(): void
     {
         $driver = $this->driver();
@@ -141,6 +161,34 @@ class ZibalTest extends DriverTestCase
         $this->assertSame('6037****1234', $receipt->getDetail('cardNumber'));
         $this->assertRequestedUrl($this->settings()['apiVerificationUrl']);
         $this->assertSame(1234567, $this->requestJson()['trackId']);
+    }
+
+    public function testVerifySendsTheConfiguredReferer(): void
+    {
+        $this->fakeRequest(['success' => 1, 'trackId' => 1234567]);
+
+        $driver = $this->driver(['referer' => 'https://example.com']);
+        $this->fakeHttp($driver, [
+            $this->jsonResponse(['result' => 100, 'refNumber' => 'ref-1']),
+        ]);
+
+        $driver->verify();
+
+        $this->assertSame('https://example.com', $this->request()->getHeaderLine('Referer'));
+    }
+
+    public function testVerifyOmitsTheRefererByDefault(): void
+    {
+        $this->fakeRequest(['success' => 1, 'trackId' => 1234567]);
+
+        $driver = $this->driver();
+        $this->fakeHttp($driver, [
+            $this->jsonResponse(['result' => 100, 'refNumber' => 'ref-1']),
+        ]);
+
+        $driver->verify();
+
+        $this->assertFalse($this->request()->hasHeader('Referer'));
     }
 
     public function testVerifyFailsWhenThePaymentWasNotSuccessful(): void


### PR DESCRIPTION
## Description

Added configurable `Referer` support to Zibal payment requests.

The `referer` option is now available in the Zibal driver configuration and defaults to `null`. When configured, it is sent as the `Referer` header in both purchase and verification requests; otherwise, the header is omitted.

## Motivation and context

Zibal requires a `Referer` header in payment requests by September 11 (20 Shahrivar). Making the value configurable lets applications provide their approved domain without coupling the driver to Laravel’s `app.url` configuration.

**Responsible team:** Backend Team

## How has this been tested?

Added unit tests covering both Zibal purchase and verification requests:

- The configured `referer` value is sent as the `Referer` header.
- The header is omitted when `referer` remains at its default `null` value.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.